### PR TITLE
refactor: move S3 utility functions to shared utils folder for reuse …

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
 services:
   pdf_processor_service:
     build:
-      context: ./pdf_processor_service
+      context: .
+      dockerfile: ./pdf_processor_service/Dockerfile
     container_name: pdf_processor_service
     ports:
       - "8000:8000"

--- a/pdf_processor_service/Dockerfile
+++ b/pdf_processor_service/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.13-slim
 
 WORKDIR /app
 
-ENV PYTHONPATH=/app/pdf_processor_service
+ENV PYTHONPATH=/app/pdf_processor_service:/app/shared_utils
 
 RUN apt-get update && apt-get install -y build-essential && rm -rf /var/lib/apt/lists/*
 

--- a/pdf_processor_service/Dockerfile
+++ b/pdf_processor_service/Dockerfile
@@ -1,23 +1,22 @@
-# Use official Python base image
 FROM python:3.13-slim
 
-# Set working directory
 WORKDIR /app
 
-# Install system dependencies
-RUN apt-get update && apt-get install -y \
-    build-essential \
- && rm -rf /var/lib/apt/lists/*
+ENV PYTHONPATH=/app/pdf_processor_service
 
-# Copy requirements and install Python packages
-COPY requirements.txt .
+RUN apt-get update && apt-get install -y build-essential && rm -rf /var/lib/apt/lists/*
+
+# Copy requirements.txt from pdf_processor_service folder in root context
+COPY pdf_processor_service/requirements.txt .
+
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy the actual application code
-COPY . .
+# Copy utils folder from root context into /app/utils
+COPY shared_utils ./shared_utils
 
-# Expose the port FastAPI will run on
+# Copy pdf_processor_service folder from root context into /app/pdf_processor_service
+COPY pdf_processor_service ./pdf_processor_service
+
 EXPOSE 8000
 
-# Run the app using Uvicorn
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["sh", "-c", "PYTHONPATH=/app/pdf_processor_service uvicorn pdf_processor_service.main:app --host 0.0.0.0 --port 8000"]

--- a/pdf_processor_service/routers/documents/upload.py
+++ b/pdf_processor_service/routers/documents/upload.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, File, UploadFile, HTTPException
 import uuid
 import logging
-from s3_utils import upload_fileobj, generate_presigned_url
+from shared_utils.s3_utils import upload_fileobj, generate_presigned_url
 from models.document import DocumentUploadResponse
 
 router = APIRouter()

--- a/shared_utils/s3_utils.py
+++ b/shared_utils/s3_utils.py
@@ -51,3 +51,28 @@ def generate_presigned_url(key: str, expiry_seconds: int = 300) -> Optional[str]
     except (BotoCoreError, ClientError) as e:
         logger.exception(f"Failed to generate presigned URL: {e}")
         return None
+    
+def get_fileobj(key: str):
+    """
+    Retrieves a file object (StreamingBody) from S3 for the given key.
+    Raises exceptions on failure.
+    """
+    try:
+        response = s3_client.get_object(Bucket=S3_BUCKET, Key=key)
+        return response["Body"] 
+    except (BotoCoreError, ClientError) as e:
+        logger.exception(f"Failed to get file from S3: {e}")
+        raise
+
+def delete_file(key: str) -> bool:
+    """
+    Deletes a file from S3 using the given key.
+    Returns True if successful, False otherwise.
+    """
+    try:
+        s3_client.delete_object(Bucket=S3_BUCKET, Key=key)
+        logger.info(f"Deleted file with key: {key}")
+        return True
+    except (BotoCoreError, ClientError) as e:
+        logger.exception(f"Failed to delete file from S3: {e}")
+        return False

--- a/shared_utils/s3_utils.py
+++ b/shared_utils/s3_utils.py
@@ -51,17 +51,6 @@ def generate_presigned_url(key: str, expiry_seconds: int = 300) -> Optional[str]
     except (BotoCoreError, ClientError) as e:
         logger.exception(f"Failed to generate presigned URL: {e}")
         return None
-def get_fileobj(key: str):
-    """
-    Retrieves a file object (StreamingBody) from S3 for the given key.
-    Raises exceptions on failure.
-    """
-    try:
-        response = s3_client.get_object(Bucket=S3_BUCKET, Key=key)
-        return response["Body"] 
-    except (BotoCoreError, ClientError) as e:
-        logger.exception(f"Failed to get file from S3: {e}")
-        raise
 
 def delete_file(key: str) -> bool:
     """

--- a/shared_utils/s3_utils.py
+++ b/shared_utils/s3_utils.py
@@ -51,7 +51,6 @@ def generate_presigned_url(key: str, expiry_seconds: int = 300) -> Optional[str]
     except (BotoCoreError, ClientError) as e:
         logger.exception(f"Failed to generate presigned URL: {e}")
         return None
-    
 def get_fileobj(key: str):
     """
     Retrieves a file object (StreamingBody) from S3 for the given key.


### PR DESCRIPTION
## Pull Request: Refactor S3 Utility for Shared Use and Add Download/Delete Functions

### Related Issues
[#34](https://github.com/NotYuSheng/OmniPDF/issues/34)

### Description

This PR refactors the existing S3 utility by moving it from the `pdf_processor_service` folder into a shared `utils` directory to enable reuse across multiple services. Additionally, it adds new functions to download and delete files from S3 by their document ID.

### Changes

- Moved `s3_utils.py` to `shared/utils/` 
- Updated import paths in `pdf_processor_service` and other affected modules
- Added new functions:
  - `get_fileobj`
  - `delete_file`
- Verified existing functionality and new functions with tests

### Why

Currently, the S3 utility is tightly coupled to one service, causing code duplication and limiting reusability. Moving it to a shared module improves maintainability and allows other services to leverage the same S3 logic. The new download and delete functions enhance the utility’s capability to manage files on S3.
