### PR TITLE
feat(ci): Add Trivy CVE scanning before image publish

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,88 @@
+name: Build, Scan, and Publish to GHCR
+
+on:
+  push:
+    branches: [dev]
+  release:
+    types: [created]
+  workflow_dispatch:
+
+jobs:
+  build-scan-push:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Install Trivy CLI
+        run: |
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
+
+      - name: Extract metadata
+        id: meta
+        run: |
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          echo "SHORT_SHA=$SHORT_SHA" >> $GITHUB_ENV
+
+          if [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
+            TAG_NAME="${{ github.event.release.tag_name }}"
+            echo "GIT_TAG=$TAG_NAME" >> $GITHUB_ENV
+            echo "IS_RELEASE=true" >> $GITHUB_ENV
+          else
+            git fetch --tags
+            LATEST_TAG=$(git tag --list 'v*.*.*' | sort -V | tail -n1)
+            FALLBACK_TAG="${LATEST_TAG:-v0.0.0}"
+            echo "GIT_TAG=${FALLBACK_TAG}-${SHORT_SHA}" >> $GITHUB_ENV
+            echo "IS_RELEASE=false" >> $GITHUB_ENV
+          fi
+
+          echo "REPO_OWNER_LC=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
+
+      - name: Build all Docker Compose services
+        run: |
+          echo "Building services from docker-compose.yml..."
+          docker compose build
+
+      - name: Run Trivy scan for all services
+        run: |
+          echo "Running Trivy scans..."
+          SERVICES=$(docker compose config --services)
+          for SERVICE in $SERVICES; do
+            IMAGE_ID=$(docker compose images -q $SERVICE)
+            echo "Scanning $SERVICE ($IMAGE_ID)..."
+            trivy image --exit-code 1 --severity CRITICAL,HIGH --no-progress $IMAGE_ID
+          done
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push scanned images to GHCR
+        run: |
+          SERVICES=$(docker compose config --services)
+          for SERVICE in $SERVICES; do
+            IMAGE_ID=$(docker compose images -q $SERVICE)
+            VERSION_TAG="ghcr.io/${{ env.REPO_OWNER_LC }}/$SERVICE:${{ env.GIT_TAG }}"
+
+            echo "Tagging and pushing $SERVICE as $VERSION_TAG"
+            docker tag $IMAGE_ID $VERSION_TAG
+            docker push $VERSION_TAG
+
+            if [[ "${{ env.IS_RELEASE }}" == "true" ]]; then
+              LATEST_TAG="ghcr.io/${{ env.REPO_OWNER_LC }}/$SERVICE:latest"
+              docker tag $IMAGE_ID $LATEST_TAG
+              docker push $LATEST_TAG
+            fi
+          done


### PR DESCRIPTION
### Summary

Adds Trivy vulnerability scanning for all Docker Compose services as part of the GitHub Actions CI pipeline. This ensures images are scanned **before** being published to GHCR, and publishing is aborted if critical or high CVEs are found.

Part of #4 

---

### Changes Made

<!-- List out major changes in this PR. Be brief but specific. -->

* Integrated Trivy (`aquasecurity/trivy-action`) into the CI workflow
* Configured `docker compose build` to build all services locally
* Automatically runs `trivy image` on each built service image
* Fails workflow if any `CRITICAL` or `HIGH` CVEs are detected
* Only pushes images to GHCR if all scans pass

---

### Context / Rationale

As part of securing our container pipeline, this PR introduces vulnerability scanning using [Trivy](https://github.com/aquasecurity/trivy). This ensures we never publish images with known critical/high CVEs to GHCR. It also aligns with secure software supply chain practices and prepares us for future staging/release automation.

This change enables earlier failure in CI and prevents costly reverts due to unsafe image promotion.

---

### General Checklist

- [x] I have tested these changes locally
- [x] I have updated relevant documentation or added comments where needed
- [x] I have linked relevant issues and tagged reviewers
- [x] I have followed coding conventions and naming standards
