### PR TITLE
ci: add standalone Trivy scan workflow with automatic .env setup

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,17 +1,13 @@
-name: Build, Scan, and Publish to GHCR
+name: Trivy Scan
 
 on:
   push:
     branches: [dev]
-  release:
-    types: [created]
   workflow_dispatch:
 
 jobs:
-  build-scan-push:
+  trivy-scan:
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
 
     steps:
       - name: Checkout repository
@@ -33,19 +29,20 @@ jobs:
           SHORT_SHA=$(git rev-parse --short HEAD)
           echo "SHORT_SHA=$SHORT_SHA" >> $GITHUB_ENV
 
-          if [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
-            TAG_NAME="${{ github.event.release.tag_name }}"
-            echo "GIT_TAG=$TAG_NAME" >> $GITHUB_ENV
-            echo "IS_RELEASE=true" >> $GITHUB_ENV
-          else
-            git fetch --tags
-            LATEST_TAG=$(git tag --list 'v*.*.*' | sort -V | tail -n1)
-            FALLBACK_TAG="${LATEST_TAG:-v0.0.0}"
-            echo "GIT_TAG=${FALLBACK_TAG}-${SHORT_SHA}" >> $GITHUB_ENV
-            echo "IS_RELEASE=false" >> $GITHUB_ENV
-          fi
-
+          git fetch --tags
+          LATEST_TAG=$(git tag --list 'v*.*.*' | sort -V | tail -n1)
+          FALLBACK_TAG="${LATEST_TAG:-v0.0.0}"
+          echo "GIT_TAG=${FALLBACK_TAG}-${SHORT_SHA}" >> $GITHUB_ENV
           echo "REPO_OWNER_LC=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
+
+      - name: Copy example.env files to .env
+        run: |
+          echo "Replicating example.env files..."
+          find . -name "example.env" | while read f; do
+            target="$(dirname "$f")/.env"
+            cp "$f" "$target"
+            echo "✓ Created $target"
+          done
 
       - name: Build all Docker Compose services
         run: |
@@ -60,29 +57,4 @@ jobs:
             IMAGE_ID=$(docker compose images -q $SERVICE)
             echo "Scanning $SERVICE ($IMAGE_ID)..."
             trivy image --exit-code 1 --severity CRITICAL,HIGH --no-progress $IMAGE_ID
-          done
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Push scanned images to GHCR
-        run: |
-          SERVICES=$(docker compose config --services)
-          for SERVICE in $SERVICES; do
-            IMAGE_ID=$(docker compose images -q $SERVICE)
-            VERSION_TAG="ghcr.io/${{ env.REPO_OWNER_LC }}/$SERVICE:${{ env.GIT_TAG }}"
-
-            echo "Tagging and pushing $SERVICE as $VERSION_TAG"
-            docker tag $IMAGE_ID $VERSION_TAG
-            docker push $VERSION_TAG
-
-            if [[ "${{ env.IS_RELEASE }}" == "true" ]]; then
-              LATEST_TAG="ghcr.io/${{ env.REPO_OWNER_LC }}/$SERVICE:latest"
-              docker tag $IMAGE_ID $LATEST_TAG
-              docker push $LATEST_TAG
-            fi
           done


### PR DESCRIPTION
### Summary

Adds a dedicated GitHub Actions workflow (`trivy.yml`) to scan all Docker Compose services for vulnerabilities using Trivy. This workflow builds services locally, replicates any `example.env` files to `.env` as required for successful builds, and fails early if any critical or high CVEs are detected.

Part of #4

---

### Changes Made

* Created new workflow file `.github/workflows/trivy.yml`
* Automatically detects and copies `example.env` → `.env` across all service folders
* Builds all services using `docker compose build`
* Runs Trivy scan on each service image
* Removes all GHCR publishing steps from this workflow

---

### Context / Rationale

This workflow separates vulnerability scanning from image publishing, allowing us to enforce security gates before pushing to GHCR. By splitting the steps, we reduce the risk of publishing unsafe images and improve auditability. It also sets up `.env` files from version-controlled `example.env` files to avoid build failures in CI.

Future publish workflows (e.g., `publish-after-trivy.yml`) will run **only after this scan passes**.

---

### General Checklist

- [x] I have tested these changes locally
- [x] I have updated relevant documentation or added comments where needed
- [x] I have linked relevant issues and tagged reviewers
- [x] I have followed coding conventions and naming standards
