### PR TITLE
ci: Improve Trivy Scan Workflow with `.env` Setup and Service Exclusion

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   trivy-scan:
     runs-on: ubuntu-latest
+    env:
+      TRIVY_EXCLUDE_SERVICES: ${{ secrets.TRIVY_EXCLUDE_SERVICES }}
 
     steps:
       - name: Checkout repository
@@ -35,13 +37,12 @@ jobs:
           echo "GIT_TAG=${FALLBACK_TAG}-${SHORT_SHA}" >> $GITHUB_ENV
           echo "REPO_OWNER_LC=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
 
-      - name: Copy example.env files to .env
+      - name: Copy example.env to .env
         run: |
-          echo "Replicating example.env files..."
+          echo "Copying example.env to .env..."
           find . -name "example.env" | while read f; do
-            target="$(dirname "$f")/.env"
-            cp "$f" "$target"
-            echo "✓ Created $target"
+            cp "$f" "$(dirname "$f")/.env"
+            echo "✓ Created $(dirname "$f")/.env"
           done
 
       - name: Build all Docker Compose services
@@ -53,8 +54,20 @@ jobs:
         run: |
           echo "Running Trivy scans..."
           SERVICES=$(docker compose config --services)
+
           for SERVICE in $SERVICES; do
+            if [[ " $TRIVY_EXCLUDE_SERVICES " =~ " $SERVICE " ]]; then
+              echo "Skipping $SERVICE (excluded via secret)"
+              continue
+            fi
+
             IMAGE_ID=$(docker compose images -q $SERVICE)
+
+            if [[ -z "$IMAGE_ID" ]]; then
+              echo "Skipping $SERVICE (no image built)"
+              continue
+            fi
+
             echo "Scanning $SERVICE ($IMAGE_ID)..."
-            trivy image --exit-code 1 --severity CRITICAL,HIGH --no-progress $IMAGE_ID
+            trivy image --exit-code 1 --severity CRITICAL,HIGH --no-progress "$IMAGE_ID"
           done


### PR DESCRIPTION
### Summary

Enhances the Trivy scanning workflow to be more robust and configurable.
This update allows the CI pipeline to scan only relevant services by skipping infrastructure containers (e.g., `minio`, `redis`) via a GitHub secret, and ensures all services with `.env` dependencies are correctly built by copying from `example.env`.

Part of #4

---

### Changes Made

* Added a pre-build step to automatically copy all `example.env` files to `.env`
* Introduced `TRIVY_EXCLUDE_SERVICES` as a GitHub Actions secret to dynamically exclude services from scanning
* Updated the Trivy scan loop to skip services without image builds or those explicitly excluded
* Improved logging and error handling for clarity

---

### Context / Rationale

Previously, Trivy scans would fail if a service like `minio` or `redis` lacked a Docker build context, returning an empty image ID. This workflow now gracefully handles such cases and allows secure configuration of skip-lists without modifying code. It also addresses build failures caused by missing `.env` files in CI.

---

### General Checklist

- [ ] I have tested these changes locally
- [x] I have updated relevant documentation or added comments where needed
- [x] I have linked relevant issues and tagged reviewers
- [x] I have followed coding conventions and naming standards
