### PR TITLE
fix: nginx change port number

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -57,7 +57,7 @@ jobs:
             echo "Waiting for $NAME via http://localhost:8080/$PREFIX/health..."
       
             for i in {1..30}; do
-              STATUS=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost/$PREFIX/health")
+              STATUS=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:8080/$PREFIX/health")
               if [ "$STATUS" == "200" ]; then
                 echo "$NAME is healthy"
                 break

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -54,7 +54,7 @@ jobs:
       
           for NAME in $SERVICE_NAMES; do
             PREFIX=${NAME%_service}
-            echo "Waiting for $NAME via http://localhost/$PREFIX/health..."
+            echo "Waiting for $NAME via http://localhost:8080/$PREFIX/health..."
       
             for i in {1..30}; do
               STATUS=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost/$PREFIX/health")


### PR DESCRIPTION
### Summary

Port number for nginx was redefined to 8080 from 80. This change broke the health check in the cypress workflow

Fix for #84 integration test failure

---

### Changes Made

- Switch workflow to call port 8080

---

### Context / Rationale

Will keep nginx as 8080 to align with README definition for now, might switch back to 80 later for convenience.

---

### General Checklist

- [x] I have tested these changes locally
- [x] I have updated relevant documentation or added comments where needed
- [x] I have linked relevant issues and tagged reviewers
- [x] I have followed coding conventions and naming standards
