### PR TITLE
fix: doc_id is stored in redis session data instead of filename

### DIFF
--- a/cleaner/utils/cleaner.py
+++ b/cleaner/utils/cleaner.py
@@ -1,6 +1,5 @@
 import logging
 
-from shared_utils.chroma_client import get_chroma_client
 from shared_utils.redis import RedisBase, RedisSetStorage, SEPERATOR
 from shared_utils.s3_utils import delete_file, delete_folder
 

--- a/cleaner/utils/cleaner.py
+++ b/cleaner/utils/cleaner.py
@@ -1,7 +1,7 @@
 import logging
 
 from shared_utils.redis import RedisBase, RedisSetStorage, SEPERATOR
-from shared_utils.s3_utils import delete_file, delete_folder
+from shared_utils.s3_utils import delete_file, delete_folder, get_job_s3_key
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +38,7 @@ def clean_s3_folder(key: str):
         if doc_key:
             logger.info(f"deleting {doc_key}")
             delete_folder(doc_key)
-            delete_file(f"jobs/extraction/{doc_key}.json")
+            delete_file(get_job_s3_key(doc_key, "extraction"))
     del redis_set_store[key]
 
 

--- a/cleaner/utils/cleaner.py
+++ b/cleaner/utils/cleaner.py
@@ -1,7 +1,8 @@
 import logging
 
+from shared_utils.chroma_client import get_chroma_client
 from shared_utils.redis import RedisBase, RedisSetStorage, SEPERATOR
-from shared_utils.s3_utils import delete_file
+from shared_utils.s3_utils import delete_file, delete_folder
 
 logger = logging.getLogger(__name__)
 
@@ -22,12 +23,23 @@ def clean_redis_key(key: str):
 
 
 def clean_s3_files(key: str):
-    logger.info(f"deleting s3 {key}")
+    logger.info(f"deleting s3 files by filenames: {key}")
     redis_set_store = RedisSetStorage(redis_client=redis_store.client)
     for doc_key in redis_set_store[key]:
         if doc_key:
             logger.info(f"deleting {doc_key}")
             delete_file(doc_key)
+    del redis_set_store[key]
+
+
+def clean_s3_folder(key: str):
+    logger.info(f"deleting s3 files by folder: {key}")
+    redis_set_store = RedisSetStorage(redis_client=redis_store.client)
+    for doc_key in redis_set_store[key]:
+        if doc_key:
+            logger.info(f"deleting {doc_key}")
+            delete_folder(doc_key)
+            delete_file(f"jobs/extraction/{doc_key}.json")
     del redis_set_store[key]
 
 
@@ -39,10 +51,9 @@ def clean_s3_file(key: str):
 def clean_chromadb(key):
     pass
 
-
 DELETION_PREFIX_CALLBACK_DICT = {
     "S3Key": clean_s3_files,
-    "SessionHeader": clean_s3_files,
+    "SessionHeader": clean_s3_folder,
     "S3_File": clean_s3_file,
     "RedisKey": clean_redis_key,
     "ChromaDBKey": clean_chromadb,

--- a/pdf_processor_service/routers/document.py
+++ b/pdf_processor_service/routers/document.py
@@ -54,7 +54,7 @@ async def upload_document(
         logger.error(f"Unexpected error during upload: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Internal server error")
 
-    append_doc(key)
+    append_doc(doc_id)
     return DocumentUploadResponse(
         doc_id=doc_id, filename=key, download_url=presigned_url
     )

--- a/pdf_processor_service/routers/images.py
+++ b/pdf_processor_service/routers/images.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, Response
 from models.images import ImageData, ImageResponse
 from utils.session import validate_session_doc_pair
 from utils.proxy import load_or_create_job
-from shared_utils.s3_utils import s3_client, S3_BUCKET, generate_external_presigned_url
+from shared_utils.s3_utils import generate_external_presigned_url, list_folder
 
 router = APIRouter(prefix="/images", tags=["images"])
 logger = logging.getLogger(__name__)
@@ -24,9 +24,7 @@ async def get_pdf_images(
     url_list = []
 
     prefix = f"{doc_id}/images/"
-    paginator = s3_client.get_paginator('list_objects_v2')
-    pages = paginator.paginate(Bucket=S3_BUCKET, Prefix=prefix)
-    keys = [obj['Key'] for page in pages for obj in page.get('Contents', [])]
+    keys = list_folder(prefix)
     
     for key in keys:
         url = generate_external_presigned_url(key)

--- a/pdf_processor_service/utils/session.py
+++ b/pdf_processor_service/utils/session.py
@@ -83,8 +83,8 @@ def get_doc_list_append_function(
     if not validate_session_id(session_id, session_storage):
         session_id = create_new_session(response, session_storage=session_storage)
 
-    def append_doc(filename: str):
-        session_storage.add(session_id, filename)
+    def append_doc(doc_id: str):
+        session_storage.add(session_id, doc_id)
 
     return append_doc
 
@@ -93,7 +93,7 @@ def get_doc_list_remove_function(
     session_id: str = Depends(get_session_id),
     session_storage: SessionStorage = Depends(get_session_storage),
 ) -> Callable[[str], None]:
-    def remove_doc(filename: str):
-        session_storage.remove(session_id, filename)
+    def remove_doc(doc_id: str):
+        session_storage.remove(session_id, doc_id)
 
     return remove_doc

--- a/shared_utils/s3_utils.py
+++ b/shared_utils/s3_utils.py
@@ -168,7 +168,7 @@ def load_job(doc_id: str, job_type: str) -> Optional[dict]:
         job_key = get_job_s3_key(doc_id, job_type)
         response = s3_client.get_object(Bucket=S3_BUCKET, Key=job_key)
         job = json.loads(response["Body"].read().decode("utf-8"))
-        redis_flag_store.set(f"jobs/{job_type}/{doc_id}.json")
+        redis_flag_store.set(job_key)
         return {
             "doc_id": doc_id,
             "status": job.get("status", "unknown"),

--- a/shared_utils/s3_utils.py
+++ b/shared_utils/s3_utils.py
@@ -126,6 +126,10 @@ def delete_folder(key: str) -> bool:
         return False
 
 
+def get_job_s3_key(doc_id: str, job_type: str):
+    return f"jobs/{job_type}/{doc_id}.json"
+
+
 def save_job(
     doc_id: str, job_data: Union[dict, BaseModel], status: str, job_type: str
 ) -> bool:
@@ -144,10 +148,11 @@ def save_job(
         }
         file_obj = BytesIO(json.dumps(wrapped).encode("utf-8"))
 
-        redis_flag_store.set(f"jobs/{job_type}/{doc_id}.json")
+        job_key = get_job_s3_key(doc_id, job_type)
+        redis_flag_store.set(job_key)
         return upload_fileobj(
             file_obj,
-            key=f"jobs/{job_type}/{doc_id}.json",
+            key=job_key,
             content_type="application/json",
         )
     except Exception as e:
@@ -160,8 +165,8 @@ def load_job(doc_id: str, job_type: str) -> Optional[dict]:
     Loads job metadata and data from S3 given a doc_id.
     """
     try:
-        key = f"jobs/{job_type}/{doc_id}.json"
-        response = s3_client.get_object(Bucket=S3_BUCKET, Key=key)
+        job_key = get_job_s3_key(doc_id, job_type)
+        response = s3_client.get_object(Bucket=S3_BUCKET, Key=job_key)
         job = json.loads(response["Body"].read().decode("utf-8"))
         redis_flag_store.set(f"jobs/{job_type}/{doc_id}.json")
         return {

--- a/shared_utils/s3_utils.py
+++ b/shared_utils/s3_utils.py
@@ -96,6 +96,36 @@ def delete_file(key: str) -> bool:
         return False
 
 
+def list_folder(folder: str) -> list[str]:
+    paginator = s3_client.get_paginator("list_objects_v2")
+    pages = paginator.paginate(Bucket=S3_BUCKET, Prefix=folder)
+    keys = [obj["Key"] for page in pages for obj in page.get("Contents", [])]
+    return keys
+
+
+def delete_folder(key: str) -> bool:
+    """
+    Deletes a folder from S3 using the given key.
+    Returns True if the folder existed and was deleted, False if it did not exist.
+    """
+    DELETE_OBJECT_LIMIT = 1000
+    try:
+        keys = list_folder(key)
+        chunked_keys = [
+            keys[i : i + DELETE_OBJECT_LIMIT]
+            for i in range(0, len(keys), DELETE_OBJECT_LIMIT)
+        ]
+        for chunk in chunked_keys:
+            s3_client.delete_objects(
+                Bucket=S3_BUCKET,
+                Delete={"Objects": [{"Key": key} for key in chunk], "Quiet": True},
+            )
+        return True
+    except (BotoCoreError, ClientError) as e:
+        logger.exception(f"Failed to delete file from S3: {e}")
+        return False
+
+
 def save_job(
     doc_id: str, job_data: Union[dict, BaseModel], status: str, job_type: str
 ) -> bool:
@@ -113,12 +143,12 @@ def save_job(
             "data": payload,
         }
         file_obj = BytesIO(json.dumps(wrapped).encode("utf-8"))
-        
+
         redis_flag_store.set(f"jobs/{job_type}/{doc_id}.json")
         return upload_fileobj(
-            file_obj, 
-            key=f"jobs/{job_type}/{doc_id}.json", 
-            content_type="application/json"
+            file_obj,
+            key=f"jobs/{job_type}/{doc_id}.json",
+            content_type="application/json",
         )
     except Exception as e:
         logger.exception(f"Failed to save job for doc_id: {doc_id} - {e}")

--- a/shared_utils/s3_utils.py
+++ b/shared_utils/s3_utils.py
@@ -96,21 +96,21 @@ def delete_file(key: str) -> bool:
         return False
 
 
-def list_folder(folder: str) -> list[str]:
+def list_folder(folder_prefix: str) -> list[str]:
     paginator = s3_client.get_paginator("list_objects_v2")
-    pages = paginator.paginate(Bucket=S3_BUCKET, Prefix=folder)
+    pages = paginator.paginate(Bucket=S3_BUCKET, Prefix=folder_prefix)
     keys = [obj["Key"] for page in pages for obj in page.get("Contents", [])]
     return keys
 
 
-def delete_folder(key: str) -> bool:
+def delete_folder(folder_prefix: str) -> bool:
     """
     Deletes a folder from S3 using the given key.
-    Returns True if the folder existed and was deleted, False if it did not exist.
+    Returns True if the folder was deleted, False if an error occured.
     """
     DELETE_OBJECT_LIMIT = 1000
     try:
-        keys = list_folder(key)
+        keys = list_folder(folder_prefix)
         chunked_keys = [
             keys[i : i + DELETE_OBJECT_LIMIT]
             for i in range(0, len(keys), DELETE_OBJECT_LIMIT)


### PR DESCRIPTION
feat: added functions to list folders and delete folder is s3 shared_utils
feat: cleaner is enhanced to have seperate function for session cleanup

### Summary

<!-- Provide a concise summary of the changes introduced in this PR. Link to relevant issue(s) if applicable. -->

Fixes issue that the validation between doc_id and session_id would fail. This came about due to the change in storage structure of the pdf in s3. 

---

### Changes Made

<!-- List out major changes in this PR. Be brief but specific. -->

- Cleaner now has a dedicated function for session cleanup.
- The Redis session data now contains doc_id instead of the s3 key of the doc.
- S3 Utils now contains functions to list and delete folders.

---

### Context / Rationale

<!-- Why are these changes being made? Is it a bug fix, feature, refactor, etc.? Provide context to help reviewers understand your thought process. -->
It is a bug fix.

---

### FastAPI Application Checklist (**Delete if PR is not relevant**)

- [x] API follows RESTful principles (nouns in routes, proper use of verbs)
- [x] All endpoints are async and use non-blocking I/O
- [x] `/health` endpoint is implemented and returns 200 OK
- [x] Long-running operations support both job polling (e.g., via /status/{job_id} or /progress/{job_id}) and optional webhooks (if a callback_url is provided).
  - [x] If callback_url is present in the request payload, the service will POST job results to the specified URL upon completion.
  - [x] If callback_url is not provided, the client can retrieve status and results via polling endpoints.
- [x] Job results are persisted or recoverable if needed
- [x] API schema (OpenAPI) is exposed and browsable at `/docs` or `/redoc`
- [x] Branch name follows conventions (e.g., `feature/*`, `bugfix/*`) — do **not** use `dev` directly

---

### General Checklist

- [x] I have tested these changes locally
- [x] I have updated relevant documentation or added comments where needed
- [x] I have linked relevant issues and tagged reviewers
- [x] I have followed coding conventions and naming standards
