### PR TITLE
Feat/processor session doc image validation

### DIFF
--- a/nginx/example.env
+++ b/nginx/example.env
@@ -4,4 +4,3 @@ CHAT_URL=http://chat_service:8000
 DOCLING_TRANSLATION_URL=http://docling_translation_service:8000
 EMBEDDER_URL=http://embedder_service:8000
 PDF_RENDERER_URL=http://pdf_renderer_service:8000
-MINIO_ENDPOINT=http://minio:9000

--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -42,11 +42,4 @@ server {
     location /embedder/ {
         proxy_pass ${EMBEDDER_URL}/;
     }
-
-    location /file/ {
-        proxy_pass ${MINIO_ENDPOINT}/;
-        proxy_intercept_errors on;
-
-        error_page 403 /error_pages/403.html;
-    }
 }

--- a/pdf_processor_service/example.env
+++ b/pdf_processor_service/example.env
@@ -11,4 +11,4 @@ REDIS_URL="redis://redis:6379/0?decode_responses=True&protocol=3"
 EXTRACTION_URL=http://pdf_extraction_service:8000/pdf_extraction/documents/extract
 
 #External URLs
-EXTERNAL_S3_ENDPOINT="http://localhost:8080/file"
+EXTERNAL_ENDPOINT="http://localhost:8080/pdf_processor/"

--- a/pdf_processor_service/example.env
+++ b/pdf_processor_service/example.env
@@ -11,4 +11,4 @@ REDIS_URL="redis://redis:6379/0?decode_responses=True&protocol=3"
 EXTRACTION_URL=http://pdf_extraction_service:8000/pdf_extraction/documents/extract
 
 #External URLs
-EXTERNAL_ENDPOINT="http://localhost:8080/pdf_processor/"
+EXTERNAL_ENDPOINT="http://localhost:8080/pdf_processor"

--- a/pdf_processor_service/routers/document.py
+++ b/pdf_processor_service/routers/document.py
@@ -1,18 +1,20 @@
 from fastapi import APIRouter, Depends, File, UploadFile, HTTPException
+from fastapi.responses import StreamingResponse
 import uuid
 import logging
 from shared_utils.s3_utils import (
     upload_fileobj,
-    generate_external_presigned_url,
     delete_file,
     s3_client,
     S3_BUCKET,
+    download_fileobj,
 )
 from utils.session import (
     get_doc_list_append_function,
     get_doc_list_remove_function,
     validate_session_doc_pair,
 )
+from utils.proxy import generate_external_doc_url, stream_file
 from models.document import DocumentUploadResponse
 from botocore.exceptions import ClientError
 
@@ -44,20 +46,14 @@ async def upload_document(
         if not success:
             raise HTTPException(status_code=500, detail="Failed to upload file to S3")
 
-        presigned_url = generate_external_presigned_url(key)
-        if not presigned_url:
-            raise HTTPException(
-                status_code=500, detail="Failed to generate presigned URL"
-            )
+        url = generate_external_doc_url(doc_id)
 
     except Exception as e:
         logger.error(f"Unexpected error during upload: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Internal server error")
 
     append_doc(key)
-    return DocumentUploadResponse(
-        doc_id=doc_id, filename=key, download_url=presigned_url
-    )
+    return DocumentUploadResponse(doc_id=doc_id, filename=key, download_url=url)
 
 
 @router.get("/{doc_id}", response_model=DocumentUploadResponse)
@@ -69,15 +65,13 @@ async def get_document(
     # Check if object exists
     try:
         s3_client.head_object(Bucket=S3_BUCKET, Key=key)
+        file = download_fileobj(key)
     except ClientError as e:
         if e.response["Error"]["Code"] == "404":
             raise HTTPException(status_code=404, detail="Document not found")
         raise HTTPException(status_code=500, detail="Failed to check document")
 
-    presigned_url = generate_external_presigned_url(key)
-    return DocumentUploadResponse(
-        doc_id=doc_id, filename=key, download_url=presigned_url
-    )
+    return StreamingResponse(stream_file(file), media_type="application/pdf")
 
 
 @router.delete("/{doc_id}", status_code=204)

--- a/pdf_processor_service/routers/document.py
+++ b/pdf_processor_service/routers/document.py
@@ -5,8 +5,6 @@ import logging
 from shared_utils.s3_utils import (
     upload_fileobj,
     delete_file,
-    s3_client,
-    S3_BUCKET,
     download_fileobj,
 )
 from utils.session import (
@@ -64,7 +62,6 @@ async def get_document(
 
     # Check if object exists
     try:
-        s3_client.head_object(Bucket=S3_BUCKET, Key=key)
         file = download_fileobj(key)
     except ClientError as e:
         if e.response["Error"]["Code"] == "404":

--- a/pdf_processor_service/routers/document.py
+++ b/pdf_processor_service/routers/document.py
@@ -5,14 +5,14 @@ import logging
 from shared_utils.s3_utils import (
     upload_fileobj,
     delete_file,
-    download_fileobj,
+    get_object_stream,
 )
 from utils.session import (
     get_doc_list_append_function,
     get_doc_list_remove_function,
     validate_session_doc_pair,
 )
-from utils.proxy import generate_external_doc_url, stream_file
+from utils.proxy import generate_external_doc_url
 from models.document import DocumentUploadResponse
 from botocore.exceptions import ClientError
 
@@ -62,13 +62,13 @@ async def get_document(
 
     # Check if object exists
     try:
-        file = download_fileobj(key)
+        file_stream = get_object_stream(key)
     except ClientError as e:
-        if e.response["Error"]["Code"] == "404":
+        if e.response["Error"]["Code"] == "NoSuchKey":
             raise HTTPException(status_code=404, detail="Document not found")
         raise HTTPException(status_code=500, detail="Failed to check document")
 
-    return StreamingResponse(stream_file(file), media_type="application/pdf")
+    return StreamingResponse(file_stream, media_type="application/pdf")
 
 
 @router.delete("/{doc_id}", status_code=204)

--- a/pdf_processor_service/routers/document.py
+++ b/pdf_processor_service/routers/document.py
@@ -54,7 +54,7 @@ async def upload_document(
     return DocumentUploadResponse(doc_id=doc_id, filename=key, download_url=url)
 
 
-@router.get("/{doc_id}", response_model=DocumentUploadResponse)
+@router.get("/{doc_id}")
 async def get_document(
     doc_id: str, _validated: bool = Depends(validate_session_doc_pair)
 ):

--- a/pdf_processor_service/routers/document.py
+++ b/pdf_processor_service/routers/document.py
@@ -56,7 +56,7 @@ async def upload_document(
     )
 
 
-@router.get("/{doc_id}")
+@router.get("/{doc_id}", response_class=StreamingResponse)
 async def get_document(
     doc_id: str, _validated: bool = Depends(validate_session_doc_pair)
 ):

--- a/pdf_processor_service/routers/images.py
+++ b/pdf_processor_service/routers/images.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 import logging
 
 from fastapi import APIRouter, Depends, Response
@@ -7,9 +8,11 @@ from models.images import ImageData, ImageResponse
 from utils.session import validate_session_doc_pair
 from utils.proxy import load_or_create_job, generate_external_image_url
 from shared_utils.s3_utils import s3_client, S3_BUCKET, download_fileobj
+from shared_utils.redis import RedisSetWithFlagExpiry
 
 router = APIRouter(tags=["images"])
 logger = logging.getLogger(__name__)
+redis_image_sets = RedisSetWithFlagExpiry(prefix="ImageFiles", flag_prefix="S3Key", default_expiry=timedelta(hours=1))
 
 
 @router.get("/images/{doc_id}")
@@ -43,6 +46,10 @@ async def get_pdf_image(
 ):
     file_key = f"{doc_id}/images/{img_name}"
     file = download_fileobj(file_key)
+
+    # To extend expiry time for the images
+    _ = redis_image_sets[doc_id]
+
     def stream_file():
         with file:
             yield from file

--- a/pdf_processor_service/routers/images.py
+++ b/pdf_processor_service/routers/images.py
@@ -1,8 +1,9 @@
 from datetime import timedelta
 import logging
 
-from fastapi import APIRouter, Depends, Response
+from fastapi import APIRouter, Depends, Response, HTTPException
 from fastapi.responses import StreamingResponse
+from botocore.exceptions import ClientError
 
 from models.images import ImageData, ImageResponse
 from utils.session import validate_session_doc_pair
@@ -45,8 +46,16 @@ async def get_pdf_image(
         _validated: bool = Depends(validate_session_doc_pair),
 ):
     file_key = f"{doc_id}/images/{img_name}"
-    file = download_fileobj(file_key)
 
+    # Check if object exists
+    try:
+        s3_client.head_object(Bucket=S3_BUCKET, Key=file_key)
+        file = download_fileobj(file_key)
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "404":
+            raise HTTPException(status_code=404, detail="Image not found")
+        raise HTTPException(status_code=500, detail="Failed to check Image")
+    
     # To extend expiry time for the images
     _ = redis_image_sets[doc_id]
 

--- a/pdf_processor_service/routers/images.py
+++ b/pdf_processor_service/routers/images.py
@@ -6,7 +6,7 @@ from fastapi.responses import StreamingResponse
 
 from models.images import ImageData, ImageResponse
 from utils.session import validate_session_doc_pair
-from utils.proxy import load_or_create_job, generate_external_image_url
+from utils.proxy import load_or_create_job, generate_external_image_url, stream_file
 from shared_utils.s3_utils import s3_client, S3_BUCKET, download_fileobj
 from shared_utils.redis import RedisSetWithFlagExpiry
 
@@ -50,7 +50,4 @@ async def get_pdf_image(
     # To extend expiry time for the images
     _ = redis_image_sets[doc_id]
 
-    def stream_file():
-        with file:
-            yield from file
-    return StreamingResponse(stream_file(), media_type="image/png")
+    return StreamingResponse(stream_file(file), media_type="image/png")

--- a/pdf_processor_service/routers/images.py
+++ b/pdf_processor_service/routers/images.py
@@ -14,23 +14,25 @@ from shared_utils.redis import RedisSetWithFlagExpiry
 
 router = APIRouter(prefix="/images", tags=["images"])
 logger = logging.getLogger(__name__)
-redis_image_sets = RedisSetWithFlagExpiry(prefix="ImageFiles", flag_prefix="S3Key", default_expiry=timedelta(hours=1))
+redis_image_sets = RedisSetWithFlagExpiry(
+    prefix="ImageFiles", flag_prefix="S3Key", default_expiry=timedelta(hours=1)
+)
 
 
 @router.get("/{doc_id}", response_model=ImageResponse)
 async def get_pdf_images(
-        doc_id: str,
-        _validated: bool = Depends(validate_session_doc_pair),
-    job_or_reposnse = Depends(load_or_create_job)
+    doc_id: str,
+    _validated: bool = Depends(validate_session_doc_pair),
+    job_or_response=Depends(load_or_create_job),
 ):
-    if isinstance(job_or_reposnse, Response):
-        return job_or_reposnse
-    
+    if isinstance(job_or_response, Response):
+        return job_or_response
+
     url_list = []
 
     prefix = f"{doc_id}/images/"
     keys = list_folder(prefix)
-    
+
     for key in keys:
         image_name = key.rsplit("/", 1)[-1]
         url = generate_external_image_url(doc_id, image_name)
@@ -38,11 +40,12 @@ async def get_pdf_images(
 
     return ImageResponse(doc_id=doc_id, filename=f"{doc_id}.pdf", images=url_list)
 
+
 @router.get("/{doc_id}/{img_name}", response_class=StreamingResponse)
 async def get_pdf_image(
-        doc_id: str,
-        img_name: str,
-        _validated: bool = Depends(validate_session_doc_pair),
+    doc_id: str,
+    img_name: str,
+    _validated: bool = Depends(validate_session_doc_pair),
 ):
     file_key = f"{doc_id}/images/{img_name}"
 
@@ -53,7 +56,7 @@ async def get_pdf_image(
         if e.response["Error"]["Code"] == "NoSuchKey":
             raise HTTPException(status_code=404, detail="Image not found")
         raise HTTPException(status_code=500, detail="Failed to check Image")
-    
+
     # To extend expiry time for the images
     _ = redis_image_sets[doc_id]
 

--- a/pdf_processor_service/routers/images.py
+++ b/pdf_processor_service/routers/images.py
@@ -12,12 +12,12 @@ from shared_utils.s3_utils import get_object_stream, list_folder
 from shared_utils.redis import RedisSetWithFlagExpiry
 
 
-router = APIRouter(tags=["images"])
+router = APIRouter(prefix="/images", tags=["images"])
 logger = logging.getLogger(__name__)
 redis_image_sets = RedisSetWithFlagExpiry(prefix="ImageFiles", flag_prefix="S3Key", default_expiry=timedelta(hours=1))
 
 
-@router.get("/images/{doc_id}")
+@router.get("/{doc_id}", response_model=ImageResponse)
 async def get_pdf_images(
         doc_id: str,
         _validated: bool = Depends(validate_session_doc_pair),
@@ -38,7 +38,7 @@ async def get_pdf_images(
 
     return ImageResponse(doc_id=doc_id, filename=f"{doc_id}.pdf", images=url_list)
 
-@router.get("/image/{doc_id}/{img_name}")
+@router.get("/{doc_id}/{img_name}", response_class=StreamingResponse)
 async def get_pdf_image(
         doc_id: str,
         img_name: str,

--- a/pdf_processor_service/routers/images.py
+++ b/pdf_processor_service/routers/images.py
@@ -7,8 +7,8 @@ from botocore.exceptions import ClientError
 
 from models.images import ImageData, ImageResponse
 from utils.session import validate_session_doc_pair
-from utils.proxy import load_or_create_job, generate_external_image_url, stream_file
-from shared_utils.s3_utils import s3_client, S3_BUCKET, download_fileobj
+from utils.proxy import load_or_create_job, generate_external_image_url
+from shared_utils.s3_utils import s3_client, S3_BUCKET, get_object_stream
 from shared_utils.redis import RedisSetWithFlagExpiry
 
 router = APIRouter(tags=["images"])
@@ -49,13 +49,13 @@ async def get_pdf_image(
 
     # Check if object exists
     try:
-        file = download_fileobj(file_key)
+        file_stream = get_object_stream(file_key)
     except ClientError as e:
-        if e.response["Error"]["Code"] == "404":
+        if e.response["Error"]["Code"] == "NoSuchKey":
             raise HTTPException(status_code=404, detail="Image not found")
         raise HTTPException(status_code=500, detail="Failed to check Image")
     
     # To extend expiry time for the images
     _ = redis_image_sets[doc_id]
 
-    return StreamingResponse(stream_file(file), media_type="image/png")
+    return StreamingResponse(file_stream, media_type="image/png")

--- a/pdf_processor_service/routers/images.py
+++ b/pdf_processor_service/routers/images.py
@@ -49,7 +49,6 @@ async def get_pdf_image(
 
     # Check if object exists
     try:
-        s3_client.head_object(Bucket=S3_BUCKET, Key=file_key)
         file = download_fileobj(file_key)
     except ClientError as e:
         if e.response["Error"]["Code"] == "404":

--- a/pdf_processor_service/routers/images.py
+++ b/pdf_processor_service/routers/images.py
@@ -1,20 +1,20 @@
 import logging
 
 from fastapi import APIRouter, Depends, Response
+from fastapi.responses import StreamingResponse
 
 from models.images import ImageData, ImageResponse
 from utils.session import validate_session_doc_pair
-from utils.proxy import load_or_create_job
-from shared_utils.s3_utils import s3_client, S3_BUCKET, generate_external_presigned_url
+from utils.proxy import load_or_create_job, generate_external_image_url
+from shared_utils.s3_utils import s3_client, S3_BUCKET, download_fileobj
 
-router = APIRouter(prefix="/images", tags=["images"])
+router = APIRouter(tags=["images"])
 logger = logging.getLogger(__name__)
 
 
-
-@router.get("/{doc_id}")
+@router.get("/images/{doc_id}")
 async def get_pdf_images(
-        doc_id: str,    
+        doc_id: str,
         _validated: bool = Depends(validate_session_doc_pair),
     job_or_reposnse = Depends(load_or_create_job)
 ):
@@ -29,7 +29,21 @@ async def get_pdf_images(
     keys = [obj['Key'] for page in pages for obj in page.get('Contents', [])]
     
     for key in keys:
-        url = generate_external_presigned_url(key)
+        image_name = key.rsplit("/", 1)[-1]
+        url = generate_external_image_url(doc_id, image_name)
         url_list.append(ImageData(image_key=key, url=url))
 
     return ImageResponse(doc_id=doc_id, filename=f"{doc_id}.pdf", images=url_list)
+
+@router.get("/image/{doc_id}/{img_name}")
+async def get_pdf_image(
+        doc_id: str,
+        img_name: str,
+        _validated: bool = Depends(validate_session_doc_pair),
+):
+    file_key = f"{doc_id}/images/{img_name}"
+    file = download_fileobj(file_key)
+    def stream_file():
+        with file:
+            yield from file
+    return StreamingResponse(stream_file(), media_type="image/png")

--- a/pdf_processor_service/routers/json_data.py
+++ b/pdf_processor_service/routers/json_data.py
@@ -1,32 +1,29 @@
 from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import StreamingResponse
 import logging
-from shared_utils.s3_utils import (
-    generate_external_presigned_url,
-    s3_client,
-    S3_BUCKET,
-)
+from shared_utils.s3_utils import s3_client, S3_BUCKET, download_fileobj
 from utils.session import validate_session_doc_pair
+from utils.proxy import stream_file
 
 from botocore.exceptions import ClientError
 
 router = APIRouter(prefix="/json_data", tags=["json_data"])
 logger = logging.getLogger(__name__)
 
-@router.get("/{doc_id}", status_code=200)
-async def get_json(doc_id: str,
-                  json_name: str,
-                  _validated: bool = Depends(validate_session_doc_pair)
-                  ):
 
+@router.get("/{doc_id}", status_code=200)
+async def get_json(
+    doc_id: str, json_name: str, _validated: bool = Depends(validate_session_doc_pair)
+):
     key = f"{doc_id}/{json_name}.json"
 
-        # Check if object exists
+    # Check if object exists
     try:
         s3_client.head_object(Bucket=S3_BUCKET, Key=key)
+        file = download_fileobj(key)
     except ClientError as e:
         if e.response["Error"]["Code"] == "404":
             raise HTTPException(status_code=404, detail="Document not found")
         raise HTTPException(status_code=500, detail="Failed to check document")
 
-    presigned_url = generate_external_presigned_url(key)
-    return {"key": key, "url": presigned_url}
+    return StreamingResponse(stream_file(file), media_type="application/json")

--- a/pdf_processor_service/routers/json_data.py
+++ b/pdf_processor_service/routers/json_data.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
 import logging
-from shared_utils.s3_utils import s3_client, S3_BUCKET, download_fileobj
+from shared_utils.s3_utils import download_fileobj
 from utils.session import validate_session_doc_pair
 from utils.proxy import stream_file
 
@@ -19,7 +19,6 @@ async def get_json(
 
     # Check if object exists
     try:
-        s3_client.head_object(Bucket=S3_BUCKET, Key=key)
         file = download_fileobj(key)
     except ClientError as e:
         if e.response["Error"]["Code"] == "404":

--- a/pdf_processor_service/routers/json_data.py
+++ b/pdf_processor_service/routers/json_data.py
@@ -1,9 +1,8 @@
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
 import logging
-from shared_utils.s3_utils import download_fileobj
+from shared_utils.s3_utils import get_object_stream
 from utils.session import validate_session_doc_pair
-from utils.proxy import stream_file
 
 from botocore.exceptions import ClientError
 
@@ -19,10 +18,10 @@ async def get_json(
 
     # Check if object exists
     try:
-        file = download_fileobj(key)
+        file_stream = get_object_stream(key)
     except ClientError as e:
-        if e.response["Error"]["Code"] == "404":
-            raise HTTPException(status_code=404, detail="Document not found")
-        raise HTTPException(status_code=500, detail="Failed to check document")
+        if e.response["Error"]["Code"] == "NoSuchKey":
+            raise HTTPException(status_code=404, detail="JSON file not found")
+        raise HTTPException(status_code=500, detail="Failed to check JSON file")
 
-    return StreamingResponse(stream_file(file), media_type="application/json")
+    return StreamingResponse(file_stream, media_type="application/json")

--- a/pdf_processor_service/routers/json_data.py
+++ b/pdf_processor_service/routers/json_data.py
@@ -10,7 +10,7 @@ router = APIRouter(prefix="/json_data", tags=["json_data"])
 logger = logging.getLogger(__name__)
 
 
-@router.get("/{doc_id}", status_code=200)
+@router.get("/{doc_id}", response_class=StreamingResponse, status_code=200)
 async def get_json(
     doc_id: str, json_name: str, _validated: bool = Depends(validate_session_doc_pair)
 ):

--- a/pdf_processor_service/routers/tables.py
+++ b/pdf_processor_service/routers/tables.py
@@ -14,12 +14,12 @@ logger = logging.getLogger(__name__)
 async def get_pdf_tables(
     doc_id: str,
     _validated: bool = Depends(validate_session_doc_pair),
-    job_or_reposnse = Depends(load_or_create_job)
+    job_or_response = Depends(load_or_create_job)
 ):
-    if isinstance(job_or_reposnse, Response):
-        return job_or_reposnse
+    if isinstance(job_or_response, Response):
+        return job_or_response
     
-    tables = job_or_reposnse.get("data", {}).get("result", {}).get("tables")
+    tables = job_or_response.get("data", {}).get("result", {}).get("tables")
     if tables is None:
         logger.error(f"Could not find 'tables' in job result for doc_id: {doc_id}")
         raise HTTPException(status_code=500, detail="A server error has occurred.")

--- a/pdf_processor_service/routers/text_chunks.py
+++ b/pdf_processor_service/routers/text_chunks.py
@@ -14,12 +14,12 @@ logger = logging.getLogger(__name__)
 async def get_pdf_text_chunks(
     doc_id: str,
     _validated: bool = Depends(validate_session_doc_pair),
-    job_or_reposnse = Depends(load_or_create_job)
+    job_or_response = Depends(load_or_create_job)
 ):
-    if isinstance(job_or_reposnse, Response):
-        return job_or_reposnse
+    if isinstance(job_or_response, Response):
+        return job_or_response
     
-    texts = job_or_reposnse.get("data", {}).get("result", {}).get("texts")
+    texts = job_or_response.get("data", {}).get("result", {}).get("texts")
     if texts is None:
         logger.error(f"Could not find 'texts' in job result for doc_id: {doc_id}")
         raise HTTPException(status_code=500, detail="A server error has occurred.")

--- a/pdf_processor_service/utils/proxy.py
+++ b/pdf_processor_service/utils/proxy.py
@@ -56,7 +56,7 @@ async def load_or_create_job(doc_id: str) -> dict | Response:
 
 
 def generate_external_image_url(doc_id: str, image_name: str):
-    return f"{EXTERNAL_ENDPOINT}/image/{doc_id}/{image_name}"
+    return f"{EXTERNAL_ENDPOINT}/images/{doc_id}/{image_name}"
 
 
 def generate_external_doc_url(doc_id: str):

--- a/pdf_processor_service/utils/proxy.py
+++ b/pdf_processor_service/utils/proxy.py
@@ -56,6 +56,14 @@ async def load_or_create_job(doc_id: str) -> dict | Response:
     return job
 
 
+def generate_external_image_url(doc_id: str, image_name: str):
+    return f"{EXTERNAL_ENDPOINT}/image/{doc_id}/{image_name}"
+
+
+def generate_external_doc_url(doc_id: str):
+    return f"{EXTERNAL_ENDPOINT}/documents/{doc_id}"
+
+
 def stream_file(file: BytesIO):
     with file:
         yield from file

--- a/pdf_processor_service/utils/proxy.py
+++ b/pdf_processor_service/utils/proxy.py
@@ -1,3 +1,4 @@
+from io import BytesIO
 import os
 import logging
 
@@ -9,7 +10,7 @@ from shared_utils.s3_utils import load_job, generate_presigned_url
 
 logger = logging.getLogger(__name__)
 
-EXTERNAL_IMAGE_ENDPOINT = os.getenv("EXTERNAL_IMAGE_ENDPOINT")
+EXTERNAL_ENDPOINT = os.getenv("EXTERNAL_ENDPOINT")
 EXTRACTION_URL = os.getenv("EXTRACTION_URL")
 if not EXTRACTION_URL:
     raise ValueError("EXTRACTION_URL is not set")
@@ -55,5 +56,6 @@ async def load_or_create_job(doc_id: str) -> dict | Response:
     return job
 
 
-def generate_external_image_url(doc_id: str, image_name: str):
-    return f"{EXTERNAL_IMAGE_ENDPOINT}/{doc_id}/{image_name}"
+def stream_file(file: BytesIO):
+    with file:
+        yield from file

--- a/pdf_processor_service/utils/proxy.py
+++ b/pdf_processor_service/utils/proxy.py
@@ -1,4 +1,3 @@
-from io import BytesIO
 import os
 import logging
 
@@ -63,7 +62,3 @@ def generate_external_image_url(doc_id: str, image_name: str):
 def generate_external_doc_url(doc_id: str):
     return f"{EXTERNAL_ENDPOINT}/documents/{doc_id}"
 
-
-def stream_file(file: BytesIO):
-    with file:
-        yield from file

--- a/pdf_processor_service/utils/proxy.py
+++ b/pdf_processor_service/utils/proxy.py
@@ -9,7 +9,7 @@ from shared_utils.s3_utils import load_job, generate_presigned_url
 
 logger = logging.getLogger(__name__)
 
-S3_ENDPOINT = os.getenv("MINIO_ENDPOINT", "http://minio:9000")  # MinIO-compatible
+EXTERNAL_IMAGE_ENDPOINT = os.getenv("EXTERNAL_IMAGE_ENDPOINT")
 EXTRACTION_URL = os.getenv("EXTRACTION_URL")
 if not EXTRACTION_URL:
     raise ValueError("EXTRACTION_URL is not set")
@@ -53,3 +53,7 @@ async def load_or_create_job(doc_id: str) -> dict | Response:
         )
 
     return job
+
+
+def generate_external_image_url(doc_id: str, image_name: str):
+    return f"{EXTERNAL_IMAGE_ENDPOINT}/{doc_id}/{image_name}"

--- a/shared_utils/s3_utils.py
+++ b/shared_utils/s3_utils.py
@@ -48,6 +48,24 @@ def upload_fileobj(file_obj, key: str, content_type: str = "application/pdf") ->
         return False
 
 
+def download_fileobj(key: str) -> bool:
+    """
+    Downloads a file-like object from S3.
+    """
+    try:
+        f = BytesIO()
+        s3_client.download_fileobj(
+            Bucket=S3_BUCKET,
+            Key=key,
+            Fileobj=f
+        )
+        f.seek(0)
+        return f
+    except (BotoCoreError, ClientError) as e:
+        logger.exception(f"Failed to upload file to S3: {e}")
+        return False
+
+
 def generate_presigned_url(key: str, expiry_seconds: int = 300) -> Optional[str]:
     """
     Generates a presigned URL to download a file from S3.

--- a/shared_utils/s3_utils.py
+++ b/shared_utils/s3_utils.py
@@ -48,21 +48,15 @@ def upload_fileobj(file_obj, key: str, content_type: str = "application/pdf") ->
         return False
 
 
-def download_fileobj(key: str) -> BytesIO:
+def get_object_stream(key: str):
     """
-    Downloads a file-like object from S3.
+    Gets a streaming body for an object from S3.
     """
     try:
-        f = BytesIO()
-        s3_client.download_fileobj(
-            Bucket=S3_BUCKET,
-            Key=key,
-            Fileobj=f
-        )
-        f.seek(0)
-        return f
+        response = s3_client.get_object(Bucket=S3_BUCKET, Key=key)
+        return response["Body"]
     except (BotoCoreError, ClientError) as e:
-        logger.exception(f"Failed to download file from S3: {e}")
+        logger.exception(f"Failed to get object stream from S3: {e}")
         raise
 
 
@@ -123,12 +117,12 @@ def save_job(
             "data": payload,
         }
         file_obj = BytesIO(json.dumps(wrapped).encode("utf-8"))
-        
+
         redis_flag_store.set(f"jobs/{job_type}/{doc_id}.json")
         return upload_fileobj(
-            file_obj, 
-            key=f"jobs/{job_type}/{doc_id}.json", 
-            content_type="application/json"
+            file_obj,
+            key=f"jobs/{job_type}/{doc_id}.json",
+            content_type="application/json",
         )
     except Exception as e:
         logger.exception(f"Failed to save job for doc_id: {doc_id} - {e}")

--- a/shared_utils/s3_utils.py
+++ b/shared_utils/s3_utils.py
@@ -81,14 +81,6 @@ def generate_presigned_url(key: str, expiry_seconds: int = 300) -> Optional[str]
         return None
 
 
-def generate_external_presigned_url(
-    key: str, expiry_seconds: int = 300
-) -> Optional[str]:
-    return generate_presigned_url(key, expiry_seconds).replace(
-        S3_ENDPOINT, EXTERNAL_S3_ENDPOINT
-    )
-
-
 def delete_file(key: str) -> bool:
     """
     Deletes a file from S3 using the given key.

--- a/shared_utils/s3_utils.py
+++ b/shared_utils/s3_utils.py
@@ -48,7 +48,7 @@ def upload_fileobj(file_obj, key: str, content_type: str = "application/pdf") ->
         return False
 
 
-def download_fileobj(key: str) -> bool:
+def download_fileobj(key: str) -> BytesIO:
     """
     Downloads a file-like object from S3.
     """
@@ -62,8 +62,8 @@ def download_fileobj(key: str) -> bool:
         f.seek(0)
         return f
     except (BotoCoreError, ClientError) as e:
-        logger.exception(f"Failed to upload file to S3: {e}")
-        return False
+        logger.exception(f"Failed to download file from S3: {e}")
+        raise
 
 
 def generate_presigned_url(key: str, expiry_seconds: int = 300) -> Optional[str]:


### PR DESCRIPTION
### Summary

<!-- Provide a concise summary of the changes introduced in this PR. Link to relevant issue(s) if applicable. -->

To improve security, direct access to minio externally has been removed. Image, document and json file downloading endpoints have been updated to reflect this.

---

### Changes Made

<!-- List out major changes in this PR. Be brief but specific. -->

- Nginx no longer has an endpoint for minio
- pdf_processor has a new endpoint for downloading images
  - The endpoint check for the user permissions before returning the file
- The GET documents endpoint now return the file
- the GET json_file endpoint now returns the file
- All functions that return an external minio url now instead return a pdf_processor url to the respective endpoint

---

### Context / Rationale

<!-- Why are these changes being made? Is it a bug fix, feature, refactor, etc.? Provide context to help reviewers understand your thought process. -->

The change is to security in the following manners:
- Reduced attack surface externally
- Prevent stealing/ sharing of the provided urls to access the files in an unauthorised manner

---

### FastAPI Application Checklist (**Delete if PR is not relevant**)

- [x] API follows RESTful principles (nouns in routes, proper use of verbs)
- [x] All endpoints are async and use non-blocking I/O
- [x] `/health` endpoint is implemented and returns 200 OK
- [x] Long-running operations support both job polling (e.g., via /status/{job_id} or /progress/{job_id}) and optional webhooks (if a callback_url is provided).
  - [x] If callback_url is present in the request payload, the service will POST job results to the specified URL upon completion.
  - [x] If callback_url is not provided, the client can retrieve status and results via polling endpoints.
- [x] Job results are persisted or recoverable if needed
- [x] API schema (OpenAPI) is exposed and browsable at `/docs` or `/redoc`
- [x] Branch name follows conventions (e.g., `feature/*`, `bugfix/*`) — do **not** use `dev` directly

---

### General Checklist

- [x] I have tested these changes locally
- [x] I have updated relevant documentation or added comments where needed
- [x] I have linked relevant issues and tagged reviewers
- [x] I have followed coding conventions and naming standards
