### PR TITLE
feat: use static service list for GHCR workflow

### DIFF
--- a/.github/services-to-build.txt
+++ b/.github/services-to-build.txt
@@ -1,0 +1,14 @@
+# Services to build and push to GHCR
+# One service name per line
+# Comments (lines starting with #) and empty lines are ignored
+
+# Core Application Services
+chat_service
+embedder_service
+pdf_processor_service
+pdf_extraction_service
+pdf_renderer_service
+docling_translation_service
+
+# Additional services
+cleaner

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -70,12 +70,12 @@ jobs:
             echo "Created $(dirname "$f")/.env"
           done
 
-      - name: Build, tag, and push all *_service Docker Compose services
+      - name: Build, tag, and push services from services-to-build.txt
         run: |
           set -e
 
-          SERVICES=$(docker compose config --services | grep '_service$')
-          echo "Filtered services: $SERVICES"
+          SERVICES=$(grep -v '^#' .github/services-to-build.txt | grep -v '^$')
+          echo "Services to build: $SERVICES"
 
           for SERVICE in $SERVICES; do
             IMAGE_NAME="ghcr.io/${{ env.REPO_OWNER_LC }}/$SERVICE:${{ env.GIT_TAG }}"


### PR DESCRIPTION
## Summary
- Replace dynamic service discovery with static service list for GHCR workflow
- Create `.github/services-to-build.txt` to define which services to build and push
- Update `publish-ghcr.yml` to read from static file instead of scanning for `*_service` pattern

## Changes Made
- **New file**: `.github/services-to-build.txt`
  - Contains list of services to build: chat_service, embedder_service, pdf_processor_service, pdf_extraction_service, pdf_renderer_service, docling_translation_service, cleaner
  - Supports comments and empty lines
  - Includes cleaner service without `_service` suffix
- **Updated workflow**: `.github/workflows/publish-ghcr.yml`
  - Changed from `docker compose config --services | grep '_service$'` to reading from static file
  - Uses `grep -v '^#'` to filter out comments and empty lines

## Problem Solved
- Previous workflow excluded `cleaner` service because it doesn't follow `*_service` naming pattern
- Avoided building infrastructure services (minio, nginx, chromadb, redis) by hardcoding the filter
- Static list provides explicit control over which services get pushed to GHCR

## Test Plan
- [ ] Verify workflow reads services correctly from static file
- [ ] Confirm all OmniPDF services are included (including cleaner)
- [ ] Ensure infrastructure services are excluded
- [ ] Test workflow execution (can be done manually via workflow_dispatch)

🤖 Generated with [Claude Code](https://claude.ai/code)