### PR TITLE
feat: update Cypress workflow to use static service list

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -42,18 +42,23 @@ jobs:
         run: |
           docker builder prune --all --force
 
-      - name: Wait for all *_service containers (via Nginx)
+      - name: Wait for all service containers (via Nginx)
         run: |
-          echo "Detecting *_service containers..."
-          SERVICE_NAMES=$(docker compose ps --services | grep '_service')
+          echo "Reading services from services-to-build.txt..."
+          SERVICE_NAMES=$(grep -v '^#' .github/services-to-build.txt | grep -v '^$')
       
           if [ -z "$SERVICE_NAMES" ]; then
-            echo "No *_service services found. Exiting."
+            echo "No services found in services-to-build.txt. Exiting."
             exit 1
           fi
       
           for NAME in $SERVICE_NAMES; do
-            PREFIX=${NAME%_service}
+            # Handle cleaner service (no _service suffix) and regular services
+            if [[ "$NAME" == "cleaner" ]]; then
+              PREFIX="cleaner"
+            else
+              PREFIX=${NAME%_service}
+            fi
             echo "Waiting for $NAME via http://localhost:8080/$PREFIX/health..."
       
             for i in {1..30}; do


### PR DESCRIPTION
## Summary
- Update Cypress integration test workflow to use static service list from `services-to-build.txt`
- Replace dynamic service discovery with consistent static approach
- Ensure cleaner service (without `_service` suffix) is properly handled

## Changes Made
- **Updated workflow**: `.github/workflows/integration-test.yaml`
  - Changed from `docker compose ps --services | grep '_service'` to reading from `services-to-build.txt`
  - Added logic to handle cleaner service prefix correctly
  - Updated error messages and comments for clarity

## Problem Solved
- Cypress workflow was using different service discovery than GHCR workflow
- Inconsistent handling of cleaner service (no `_service` suffix)
- Makes service management consistent across all workflows

## Dependencies
- Requires `services-to-build.txt` file (already merged to dev)
- Consistent with GHCR workflow changes in PR #139

## Test Plan
- [ ] Verify workflow reads services correctly from static file
- [ ] Confirm health check URLs are generated properly for all services
- [ ] Test with cleaner service prefix logic
- [ ] Validate integration test execution

🤖 Generated with [Claude Code](https://claude.ai/code)