### PR TITLE
fix: replace curl with Python urllib for health checks

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -65,8 +65,15 @@ jobs:
             echo "Waiting for $NAME to be healthy..."
       
             for i in {1..30}; do
-              # Execute health check directly inside the container
-              STATUS=$(docker exec "$NAME" curl -s -o /dev/null -w "%{http_code}" "http://localhost:8000/health" 2>/dev/null || echo "000")
+              # Execute health check using Python (available in all containers)
+              STATUS=$(docker exec "$NAME" python3 -c "
+import urllib.request
+try:
+    response = urllib.request.urlopen('http://localhost:8000/health', timeout=5)
+    print(response.getcode())
+except Exception as e:
+    print('000')
+" 2>/dev/null || echo "000")
               if [ "$STATUS" == "200" ]; then
                 echo "$NAME is healthy"
                 break

--- a/cypress/e2e/placeholder.cy.js
+++ b/cypress/e2e/placeholder.cy.js
@@ -36,11 +36,20 @@ describe('Service Health Tests', () => {
     services.forEach(service => {
       cy.task('dockerExec', { 
         containerName: service,
-        args: ['curl', '-f', 'http://localhost:8000/health'],
+        args: ['python3', '-c', `
+import urllib.request
+try:
+    response = urllib.request.urlopen('http://localhost:8000/health', timeout=5)
+    print(f'HTTP {response.getcode()}')
+    exit(0 if response.getcode() == 200 else 1)
+except Exception as e:
+    print(f'Health check failed: {e}')
+    exit(1)
+`],
         timeout: 10000 
       }).then((result) => {
-        expect(result.code, `Health check for '${service}' failed. Command: docker exec ${service} curl -f http://localhost:8000/health. Stdout: ${result.stdout}. Stderr: ${result.stderr}`).to.eq(0);
-        cy.log(`✓ ${service} is healthy`);
+        expect(result.code, `Health check for '${service}' failed. Command: docker exec ${service} python3 health check. Stdout: ${result.stdout}. Stderr: ${result.stderr}`).to.eq(0);
+        cy.log(`✓ ${service} is healthy (${result.stdout.trim()})`);
       });
     });
   });


### PR DESCRIPTION
### Summary

Fixes the "curl: executable file not found" error in container health checks by replacing curl commands with Python's built-in urllib.request module, which is available in all service containers.

Fixes the issue identified in PR #141 where health checks were failing due to missing curl in containers.

---

### Changes Made

- Replace `curl` commands with Python `urllib.request` in GitHub Actions workflow
- Update Cypress tests to use Python for HTTP health checks instead of curl
- Both approaches now use Python 3 which is available in all service containers (based on `python:3.13-slim`)
- Maintains same functionality while fixing compatibility issues

---

### Context / Rationale

The service containers are based on `python:3.13-slim` images which don't include curl by default. Rather than installing curl in each container, using Python's built-in urllib module is more efficient and doesn't require additional dependencies.

---

### Testing

- ✅ Built and tested `chat_service` and `embedder_service` locally
- ✅ Verified Python health checks return HTTP 200 for healthy services
- ✅ Tested both Cypress-style and workflow-style health check approaches

---

### General Checklist

- [x] I have tested these changes locally
- [x] I have verified the fix works with actual running containers
- [x] I have followed coding conventions and naming standards
- [x] Changes maintain security improvements from previous PR

🤖 Generated with [Claude Code](https://claude.ai/code)