### PR TITLE
fix: correct YAML syntax for Python health check command

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -66,14 +66,7 @@ jobs:
       
             for i in {1..30}; do
               # Execute health check using Python (available in all containers)
-              STATUS=$(docker exec "$NAME" python3 -c "
-import urllib.request
-try:
-    response = urllib.request.urlopen('http://localhost:8000/health', timeout=5)
-    print(response.getcode())
-except Exception as e:
-    print('000')
-" 2>/dev/null || echo "000")
+              STATUS=$(docker exec "$NAME" python3 -c 'import urllib.request; response = urllib.request.urlopen("http://localhost:8000/health", timeout=5); print(response.getcode())' 2>/dev/null || echo "000")
               if [ "$STATUS" == "200" ]; then
                 echo "$NAME is healthy"
                 break


### PR DESCRIPTION
### Summary

Fixes YAML syntax error on line 70 in the GitHub Actions workflow introduced in the previous Python health check fix.

---

### Changes Made

- Convert multi-line Python code to single-line command for proper shell escaping
- Fixes syntax error that was breaking the workflow

---

### Context / Rationale

The multi-line Python string wasn't properly escaped in the YAML file, causing a syntax error. Converting to a single-line command resolves the issue while maintaining the same functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)