### PR TITLE
Feat/frontend metadata

### DIFF
--- a/frontend/components/documents.py
+++ b/frontend/components/documents.py
@@ -1,0 +1,75 @@
+import streamlit as st
+
+
+def get_document_names():
+    response_lst = list(st.session_state.processed_data.items())
+    return [data["uploaded_filename"] for _, data in response_lst]
+
+
+def get_document_ids():
+    return st.session_state.processed_data.keys()
+
+
+def document_multiselect_with_expander():
+    document_multiselect = DocumentMultiSelect()
+    doc_names = get_document_names()
+    doc_ids = get_document_ids()
+    expander_list = []
+    for doc_name, doc_id in zip(doc_names, doc_ids):
+        expander_list.append(DocumentExpander(doc_id, doc_name, document_multiselect))
+    return expander_list
+
+class DocumentMultiSelect():
+    def __init__(self):
+        # Update multiselect based on expander states
+        self.doc_names = get_document_names()
+        self.multiselect = st.multiselect(
+            label="Expand documents:",
+            options=self.doc_names,
+            default=[
+                doc for doc in self.doc_names if st.session_state.expander_states.get(doc, True)
+            ],
+            help="Choose which documents should be expanded",
+            key="expander_multiselect",
+        )
+        
+        # Update session state based on multiselect
+        for doc_name in self.doc_names:
+            st.session_state.expander_states[doc_name] = doc_name in self.multiselect
+
+    def __contains__(self, item):
+        return item in self.multiselect
+    
+    def remove(self, item):
+        return self.multiselect.remove(item)
+
+class DocumentExpander():
+    def __init__(self, doc_id: str, doc_name: str, doc_multiselect: DocumentMultiSelect):
+        self.doc_id = doc_id
+        self.doc_name = doc_name
+        self.expander = st.expander(
+                        label=f"**{doc_name}**",
+                        expanded=st.session_state.expander_states.get(
+                            doc_name, True
+                        ),
+                    )
+        self.status = None
+        
+        # Update expander state and multiselect when expander is toggled
+        if not self.expander:  # expander is closed
+            st.session_state.expander_states[doc_name] = (
+                False
+            )
+            if doc_name in doc_multiselect:
+                doc_multiselect.remove(doc_name)
+        else:  # expander is open
+            st.session_state.expander_states[doc_name] = (
+                True
+            )
+        
+    def __enter__(self):
+        self.expander.__enter__()
+        self.status = st.empty()
+
+    def __exit__(self, *exc_details):
+        self.expander.__exit__(*exc_details)

--- a/frontend/components/documents.py
+++ b/frontend/components/documents.py
@@ -2,8 +2,7 @@ import streamlit as st
 
 
 def get_document_names():
-    response_lst = list(st.session_state.processed_data.items())
-    return [data["uploaded_filename"] for _, data in response_lst]
+    return [data["uploaded_filename"] for data in st.session_state.processed_data.values()]
 
 
 def get_document_ids():

--- a/frontend/components/documents.py
+++ b/frontend/components/documents.py
@@ -38,9 +38,7 @@ class DocumentMultiSelect():
 
     def __contains__(self, item):
         return item in self.multiselect
-    
-    def remove(self, item):
-        return self.multiselect.remove(item)
+
 
 class DocumentExpander():
     def __init__(self, doc_id: str, doc_name: str, doc_multiselect: DocumentMultiSelect):
@@ -59,8 +57,6 @@ class DocumentExpander():
             st.session_state.expander_states[doc_name] = (
                 False
             )
-            if doc_name in doc_multiselect:
-                doc_multiselect.remove(doc_name)
         else:  # expander is open
             st.session_state.expander_states[doc_name] = (
                 True

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
     )
 
     metadata_UI = st.Page(
-        page="pages/7_metadata_UI.py.py",
+        page="pages/7_metadata_UI.py",
         title="Metadata",
         icon="📄",
     )

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -104,6 +104,12 @@ if __name__ == "__main__":
         icon="📄",
     )
 
+    metadata_UI = st.Page(
+        page="pages/7_metadata_UI.py.py",
+        title="Metadata",
+        icon="📄",
+    )
+
     settings_UI = st.Page(
         page="pages/10_settings_UI.py",
         title="Settings",
@@ -119,6 +125,7 @@ if __name__ == "__main__":
             tables_UI,
             wordcloud_UI,
             translate_UI,
+            metadata_UI,
             settings_UI,
         ]
     )

--- a/frontend/pages/4_wordcloud_UI.py
+++ b/frontend/pages/4_wordcloud_UI.py
@@ -4,38 +4,59 @@ import streamlit as st
 import logging
 import json 
 import httpx
-
+from components.documents import document_multiselect_with_expander, DocumentExpander
 
 PDF_PROCESSOR_URL = os.environ["PDF_PROCESSOR_URL"]
 logger = logging.getLogger(__name__)
 client = httpx.AsyncClient(cookies=st.session_state.httpx_cookies)
 
-server_status = st.empty()
+runner = asyncio.Runner()
 # WIP - this file is not fully functional yet
 st.header("☁️ Word Cloud")
 
 
-async def get_wordcloud(doc_id: str):
-    try:
-        response = await client.get(f"{PDF_PROCESSOR_URL}/wordcloud/{doc_id}")
-
-        logger.info(f"Wordcloud response status: {response.status_code}")
+async def get_wordcloud(doc_id: str, status_bar, max_retries=600, delay=1):
+    for attempt in range(max_retries):
         try:
-            data = response.json()
-        except json.JSONDecodeError as e:
-            logger.error(
-                f"Failed to decode JSON from response: {response.text}: {e}"
-            )
-            server_status.error("Received an invalid response from the server.")
+            response = await client.get(f"{PDF_PROCESSOR_URL}/wordcloud/{doc_id}")
 
-        if response.status_code == 200:
-            return data  # Success - return the actual data
-        elif response.status_code == 202:
-            server_status.error("Document is currently processing")
-            return None
-    except httpx.RequestError as e:
-        logger.error(f"Request error on attempt: {e}")
-        raise
+            logger.info(f"Wordcloud response status: {response.status_code}")
+            try:
+                data = response.json()
+            except json.JSONDecodeError as e:
+                logger.error(
+                    f"Failed to decode JSON from response: {response.text}: {e}"
+                )
+
+            if response.status_code == 200:
+                status_bar.empty()
+                return data  # Success - return the actual data
+            elif response.status_code == 202:
+                # Still processing, continue polling
+                if attempt < max_retries - 1:
+                    if status_bar:
+                        status_bar.info(
+                            f"Document still processing... ({(attempt + 1) * delay}s)"
+                        )
+                    data = response.json()
+                    # if "detail" in data:
+                    #     server_status.info(data["detail"])
+                    # else:
+                    #     if len(data) > 100:
+                    #         server_status.info(str(data)[:50] + "...")
+                    await asyncio.sleep(delay)
+                    continue
+                else:
+                    raise TimeoutError(
+                        "Document processing timed out after maximum retries"
+                    )
+            response.raise_for_status()
+        except httpx.RequestError as e:
+            status_bar.error("Error Processing your file. Please try re uploading.")
+            logger.error(f"Request error on attempt: {e}")
+        except TimeoutError:
+            logger.error(f"Document ID: {doc_id} took too long to process.")
+            status_bar.error("Retry limit reached. Please retry by clicking on page on left.")
 
 
 async def get_wordcloud_image(doc_id: str | None):
@@ -53,14 +74,19 @@ async def get_wordcloud_image(doc_id: str | None):
         raise
 
 
-async def get_wordclouds(doc_ids: list[str]):
-    wordcloud_requests = [get_wordcloud(doc_id) for doc_id in doc_ids]
-    return await asyncio.gather(*wordcloud_requests)
+async def display_wordcloud(expander: DocumentExpander):
+    with expander:
+        res = await get_wordcloud(expander.doc_id, expander.status)
+        if res:
+            img = await get_wordcloud_image(expander.doc_id)
+            st.image(img)
+            markdown_list = [f"- {word}" for word in res["top_words"]]
+            st.markdown("\n".join(markdown_list))
 
 
-async def get_wordcloud_images(doc_ids: list[str]):
-    image_requests = [get_wordcloud_image(doc_id) for doc_id in doc_ids]
-    return await asyncio.gather(*image_requests)
+async def display_all(expanders: list[DocumentExpander]):
+    a = [display_wordcloud(expander) for expander in expanders]
+    await asyncio.gather(*a, return_exceptions= True)
 
 
 if "processed_data" in st.session_state and st.session_state.processed_data:
@@ -72,59 +98,8 @@ if "processed_data" in st.session_state and st.session_state.processed_data:
     response_lst = list(st.session_state.processed_data.items())
     doc_names = [data["uploaded_filename"] for _, data in response_lst]
 
-    # Initialize expander states for new documents
-    for doc_name in doc_names:
-        if doc_name not in st.session_state.expander_states:
-            st.session_state.expander_states[doc_name] = True
-
-    # Update multiselect based on expander states
-    expanded_docs = st.multiselect(
-        label="Expand documents:",
-        options=doc_names,
-        default=[
-            doc for doc in doc_names if st.session_state.expander_states.get(doc, True)
-        ],
-        help="Choose which documents should be expanded",
-        key="expander_multiselect",
-    )
-
-    # Update session state based on multiselect
-    for doc_name in doc_names:
-        st.session_state.expander_states[doc_name] = doc_name in expanded_docs
-
-    with asyncio.Runner() as runner:
-        wordcloud_response = runner.run(get_wordclouds(doc_ids))
-
-        successful_doc_ids = [doc_id if response is not None else None for doc_id, response in zip(doc_ids, wordcloud_response)]
-        images = runner.run(get_wordcloud_images(successful_doc_ids))
-
-    for idx, doc_name in enumerate(doc_names):
-        expander_key = f"expander_{doc_name}"
-        wordcloud_tab = st.expander(
-                        label=f"**{doc_name}**",
-                        expanded=st.session_state.expander_states.get(
-                            doc_name, True
-                        ),
-                    )
-        
-        # Update expander state and multiselect when expander is toggled
-        if not wordcloud_tab:  # expander is closed
-            st.session_state.expander_states[doc_name] = (
-                False
-            )
-            if doc_name in expanded_docs:
-                expanded_docs.remove(doc_name)
-        else:  # expander is open
-            st.session_state.expander_states[doc_name] = (
-                True
-            )
-        with wordcloud_tab:
-            if wordcloud_response is not None:
-                st.image(images[idx])
-                markdown_list = [f"- {word}" for word in wordcloud_response[idx]["top_words"]]
-                st.markdown("\n".join(markdown_list))
-            else:
-                st.text("Processing.")
+    expanders = document_multiselect_with_expander()
+    runner.run(display_all(expanders))
 
 else:
     st.info("Please upload and process a PDF first to extract images")

--- a/frontend/pages/4_wordcloud_UI.py
+++ b/frontend/pages/4_wordcloud_UI.py
@@ -2,7 +2,7 @@ import asyncio
 import os
 import streamlit as st
 import logging
-import json 
+import json
 import httpx
 from components.documents import document_multiselect_with_expander, DocumentExpander
 
@@ -36,7 +36,9 @@ async def get_wordcloud(doc_id: str, status_bar, max_retries=600, delay=1):
                 # Still processing, continue polling
                 if attempt < max_retries - 1:
                     if status_bar:
-                        reason = data.get("detail", "in progress") if data else "in progress"
+                        reason = (
+                            data.get("detail", "in progress") if data else "in progress"
+                        )
                         status_bar.info(
                             f"Document still processing... ({(attempt + 1) * delay}s)"
                             f"\nReason: {reason}"
@@ -53,14 +55,18 @@ async def get_wordcloud(doc_id: str, status_bar, max_retries=600, delay=1):
             logger.error(f"Request error on attempt: {e}")
         except TimeoutError:
             logger.error(f"Document ID: {doc_id} took too long to process.")
-            status_bar.error("Retry limit reached. Please retry by clicking on page on left.")
+            status_bar.error(
+                "Retry limit reached. Please retry by clicking on page on left."
+            )
 
 
 async def get_wordcloud_image(doc_id: str | None):
     if doc_id is None:
         return None
     try:
-        response = await client.get(f"{PDF_PROCESSOR_URL}/wordcloud/{doc_id}/wordcloud.png")
+        response = await client.get(
+            f"{PDF_PROCESSOR_URL}/wordcloud/{doc_id}/wordcloud.png"
+        )
 
         logger.info(f"Wordcloud Image response status: {response.status_code}")
         response.raise_for_status()
@@ -83,7 +89,7 @@ async def display_wordcloud(expander: DocumentExpander):
 
 async def display_all(expanders: list[DocumentExpander]):
     displays = [display_wordcloud(expander) for expander in expanders]
-    await asyncio.gather(*displays, return_exceptions= True)
+    await asyncio.gather(*displays, return_exceptions=True)
 
 
 if "processed_data" in st.session_state and st.session_state.processed_data:

--- a/frontend/pages/4_wordcloud_UI.py
+++ b/frontend/pages/4_wordcloud_UI.py
@@ -1,56 +1,130 @@
+import asyncio
+import os
 import streamlit as st
 import logging
-from streamlit.components.v1 import html
-import base64
-from components.process_pdf import generate_wordcloud
-import io
+import json 
+import httpx
 
 
+PDF_PROCESSOR_URL = os.environ["PDF_PROCESSOR_URL"]
 logger = logging.getLogger(__name__)
+client = httpx.AsyncClient(cookies=st.session_state.httpx_cookies)
 
+server_status = st.empty()
 # WIP - this file is not fully functional yet
 st.header("☁️ Word Cloud")
+
+
+async def get_wordcloud(doc_id: str):
+    try:
+        response = await client.get(f"{PDF_PROCESSOR_URL}/wordcloud/{doc_id}")
+
+        logger.info(f"Wordcloud response status: {response.status_code}")
+        try:
+            data = response.json()
+        except json.JSONDecodeError as e:
+            logger.error(
+                f"Failed to decode JSON from response: {response.text}: {e}"
+            )
+            server_status.error("Received an invalid response from the server.")
+
+        if response.status_code == 200:
+            return data  # Success - return the actual data
+        elif response.status_code == 202:
+            server_status.error("Document is currently processing")
+            return None
+    except httpx.RequestError as e:
+        logger.error(f"Request error on attempt: {e}")
+        raise
+
+
+async def get_wordcloud_image(doc_id: str | None):
+    if doc_id is None:
+        return None
+    try:
+        response = await client.get(f"{PDF_PROCESSOR_URL}/wordcloud/{doc_id}/wordcloud.png")
+
+        logger.info(f"Wordcloud Image response status: {response.status_code}")
+        response.raise_for_status()
+        # return Image.open(BytesIO(response.content))
+        return response.content
+    except httpx.RequestError as e:
+        logger.error(f"Request error on attempt: {e}")
+        raise
+
+
+async def get_wordclouds(doc_ids: list[str]):
+    wordcloud_requests = [get_wordcloud(doc_id) for doc_id in doc_ids]
+    return await asyncio.gather(*wordcloud_requests)
+
+
+async def get_wordcloud_images(doc_ids: list[str]):
+    image_requests = [get_wordcloud_image(doc_id) for doc_id in doc_ids]
+    return await asyncio.gather(*image_requests)
+
+
 if "processed_data" in st.session_state and st.session_state.processed_data:
-    # Generate word cloud from keywords
-    metadata = st.session_state.processed_data.get("metadata", {})
-    all_keywords = metadata.get("keywords", []) + metadata.get("image_keywords", [])
+    # Initialize session state for expander states if not exists
+    if "expander_states" not in st.session_state:
+        st.session_state.expander_states = {}
 
-    if all_keywords:
-        fig = generate_wordcloud(all_keywords)
-        buf = io.BytesIO()
-        fig.savefig(buf, format="png", bbox_inches="tight")
-        buf.seek(0)
-        encoded = base64.b64encode(buf.read()).decode("utf-8")
-        # Custom HTML for zoomable image
-        html_code = f"""
-        <style>
-        .zoomable-img {{
-            transition: transform 0.3s ease;
-            cursor: zoom-in;
-            max-width: 100%;
-            height: auto;
-        }}
+    doc_ids = st.session_state.processed_data.keys()
+    response_lst = list(st.session_state.processed_data.items())
+    doc_names = [data["uploaded_filename"] for _, data in response_lst]
 
-        .zoomed {{
-            transform: scale(2.5);
-            cursor: zoom-out;
-            z-index: 9999;
-            position: relative;
-        }}
-        </style>
+    # Initialize expander states for new documents
+    for doc_name in doc_names:
+        if doc_name not in st.session_state.expander_states:
+            st.session_state.expander_states[doc_name] = True
 
-        <img id="zoom-img" class="zoomable-img" src="data:image/jpeg;base64,{encoded}" onclick="toggleZoom()" />
+    # Update multiselect based on expander states
+    expanded_docs = st.multiselect(
+        label="Expand documents:",
+        options=doc_names,
+        default=[
+            doc for doc in doc_names if st.session_state.expander_states.get(doc, True)
+        ],
+        help="Choose which documents should be expanded",
+        key="expander_multiselect",
+    )
 
-        <script>
-        function toggleZoom() {{
-            var img = document.getElementById("zoom-img");
-            img.classList.toggle("zoomed");
-        }}
-        </script>
-        """
-        # Display the image using custom HTML
-        html(html_code, height=600)
-    else:
-        st.info("No keywords available for word cloud generation")
+    # Update session state based on multiselect
+    for doc_name in doc_names:
+        st.session_state.expander_states[doc_name] = doc_name in expanded_docs
+
+    with asyncio.Runner() as runner:
+        wordcloud_response = runner.run(get_wordclouds(doc_ids))
+
+        successful_doc_ids = [doc_id if response is not None else None for doc_id, response in zip(doc_ids, wordcloud_response)]
+        images = runner.run(get_wordcloud_images(successful_doc_ids))
+
+    for idx, doc_name in enumerate(doc_names):
+        expander_key = f"expander_{doc_name}"
+        wordcloud_tab = st.expander(
+                        label=f"**{doc_name}**",
+                        expanded=st.session_state.expander_states.get(
+                            doc_name, True
+                        ),
+                    )
+        
+        # Update expander state and multiselect when expander is toggled
+        if not wordcloud_tab:  # expander is closed
+            st.session_state.expander_states[doc_name] = (
+                False
+            )
+            if doc_name in expanded_docs:
+                expanded_docs.remove(doc_name)
+        else:  # expander is open
+            st.session_state.expander_states[doc_name] = (
+                True
+            )
+        with wordcloud_tab:
+            if wordcloud_response is not None:
+                st.image(images[idx])
+                markdown_list = [f"- {word}" for word in wordcloud_response[idx]["top_words"]]
+                st.markdown("\n".join(markdown_list))
+            else:
+                st.text("Processing.")
+
 else:
-    st.info("Please upload and process a PDF first to generate word cloud")
+    st.info("Please upload and process a PDF first to extract images")

--- a/frontend/pages/4_wordcloud_UI.py
+++ b/frontend/pages/4_wordcloud_UI.py
@@ -82,18 +82,14 @@ async def display_wordcloud(expander: DocumentExpander):
 
 
 async def display_all(expanders: list[DocumentExpander]):
-    a = [display_wordcloud(expander) for expander in expanders]
-    await asyncio.gather(*a, return_exceptions= True)
+    displays = [display_wordcloud(expander) for expander in expanders]
+    await asyncio.gather(*displays, return_exceptions= True)
 
 
 if "processed_data" in st.session_state and st.session_state.processed_data:
     # Initialize session state for expander states if not exists
     if "expander_states" not in st.session_state:
         st.session_state.expander_states = {}
-
-    doc_ids = st.session_state.processed_data.keys()
-    response_lst = list(st.session_state.processed_data.items())
-    doc_names = [data["uploaded_filename"] for _, data in response_lst]
 
     expanders = document_multiselect_with_expander()
     runner.run(display_all(expanders))

--- a/frontend/pages/4_wordcloud_UI.py
+++ b/frontend/pages/4_wordcloud_UI.py
@@ -24,6 +24,7 @@ async def get_wordcloud(doc_id: str, status_bar, max_retries=600, delay=1):
             try:
                 data = response.json()
             except json.JSONDecodeError as e:
+                data = {}
                 logger.error(
                     f"Failed to decode JSON from response: {response.text}: {e}"
                 )
@@ -35,15 +36,11 @@ async def get_wordcloud(doc_id: str, status_bar, max_retries=600, delay=1):
                 # Still processing, continue polling
                 if attempt < max_retries - 1:
                     if status_bar:
+                        reason = data.get("detail", "in progress") if data else "in progress"
                         status_bar.info(
                             f"Document still processing... ({(attempt + 1) * delay}s)"
+                            f"\nReason: {reason}"
                         )
-                    data = response.json()
-                    # if "detail" in data:
-                    #     server_status.info(data["detail"])
-                    # else:
-                    #     if len(data) > 100:
-                    #         server_status.info(str(data)[:50] + "...")
                     await asyncio.sleep(delay)
                     continue
                 else:

--- a/frontend/pages/7_metadata_UI.py
+++ b/frontend/pages/7_metadata_UI.py
@@ -24,6 +24,7 @@ async def get_metadata(doc_id: str, status_bar, max_retries=600, delay=1):
             try:
                 data = response.json()
             except json.JSONDecodeError as e:
+                data = {}
                 logger.error(
                     f"Failed to decode JSON from response: {response.text}: {e}"
                 )
@@ -35,11 +36,11 @@ async def get_metadata(doc_id: str, status_bar, max_retries=600, delay=1):
                 # Still processing, continue polling
                 if attempt < max_retries - 1:
                     if status_bar:
+                        reason = data.get("detail", "in progress") if data else "in progress"
                         status_bar.info(
-                            f"Document still processing... ({(attempt + 1) * delay}s)" +
-                            f"\nReason: {data['detail']}"
+                            f"Document still processing... ({(attempt + 1) * delay}s)"
+                            f"\nReason: {reason}"
                         )
-                    data = response.json()
                     await asyncio.sleep(delay)
                     continue
                 else:

--- a/frontend/pages/7_metadata_UI.py
+++ b/frontend/pages/7_metadata_UI.py
@@ -1,0 +1,83 @@
+import asyncio
+import os
+import streamlit as st
+import logging
+import json 
+import httpx
+from components.documents import document_multiselect_with_expander, DocumentExpander
+
+PDF_PROCESSOR_URL = os.environ["PDF_PROCESSOR_URL"]
+logger = logging.getLogger(__name__)
+client = httpx.AsyncClient(cookies=st.session_state.httpx_cookies)
+
+runner = asyncio.Runner()
+# WIP - this file is not fully functional yet
+st.header("☁️ Metadata")
+
+
+async def get_metadata(doc_id: str, status_bar, max_retries=600, delay=1):
+    for attempt in range(max_retries):
+        try:
+            response = await client.get(f"{PDF_PROCESSOR_URL}/metadata/{doc_id}")
+
+            logger.info(f"metadata response status: {response.status_code}")
+            try:
+                data = response.json()
+            except json.JSONDecodeError as e:
+                logger.error(
+                    f"Failed to decode JSON from response: {response.text}: {e}"
+                )
+
+            if response.status_code == 200:
+                status_bar.empty()
+                return data  # Success - return the actual data
+            elif response.status_code == 202:
+                # Still processing, continue polling
+                if attempt < max_retries - 1:
+                    if status_bar:
+                        status_bar.info(
+                            f"Document still processing... ({(attempt + 1) * delay}s)" +
+                            f"\nReason: {data['detail']}"
+                        )
+                    data = response.json()
+                    await asyncio.sleep(delay)
+                    continue
+                else:
+                    raise TimeoutError(
+                        "Document processing timed out after maximum retries"
+                    )
+            response.raise_for_status()
+        except httpx.RequestError as e:
+            status_bar.error("Error Processing your file. Please try re uploading.")
+            logger.error(f"Request error on attempt: {e}")
+        except TimeoutError:
+            logger.error(f"Document ID: {doc_id} took too long to process.")
+            status_bar.error("Retry limit reached. Please retry by clicking on page on left.")
+
+
+async def display_metadata(expander: DocumentExpander):
+    with expander:
+        res = await get_metadata(expander.doc_id, expander.status)
+        if res:
+            st.dataframe(res["metadata"])
+
+
+async def display_all(expanders: list[DocumentExpander]):
+    a = [display_metadata(expander) for expander in expanders]
+    await asyncio.gather(*a, return_exceptions= True)
+
+
+if "processed_data" in st.session_state and st.session_state.processed_data:
+    # Initialize session state for expander states if not exists
+    if "expander_states" not in st.session_state:
+        st.session_state.expander_states = {}
+
+    doc_ids = st.session_state.processed_data.keys()
+    response_lst = list(st.session_state.processed_data.items())
+    doc_names = [data["uploaded_filename"] for _, data in response_lst]
+
+    expanders = document_multiselect_with_expander()
+    runner.run(display_all(expanders))
+
+else:
+    st.info("Please upload and process a PDF first to extract images")

--- a/frontend/pages/7_metadata_UI.py
+++ b/frontend/pages/7_metadata_UI.py
@@ -2,7 +2,7 @@ import asyncio
 import os
 import streamlit as st
 import logging
-import json 
+import json
 import httpx
 from components.documents import document_multiselect_with_expander, DocumentExpander
 
@@ -36,7 +36,9 @@ async def get_metadata(doc_id: str, status_bar, max_retries=600, delay=1):
                 # Still processing, continue polling
                 if attempt < max_retries - 1:
                     if status_bar:
-                        reason = data.get("detail", "in progress") if data else "in progress"
+                        reason = (
+                            data.get("detail", "in progress") if data else "in progress"
+                        )
                         status_bar.info(
                             f"Document still processing... ({(attempt + 1) * delay}s)"
                             f"\nReason: {reason}"
@@ -53,7 +55,9 @@ async def get_metadata(doc_id: str, status_bar, max_retries=600, delay=1):
             logger.error(f"Request error on attempt: {e}")
         except TimeoutError:
             logger.error(f"Document ID: {doc_id} took too long to process.")
-            status_bar.error("Retry limit reached. Please retry by clicking on page on left.")
+            status_bar.error(
+                "Retry limit reached. Please retry by clicking on page on left."
+            )
 
 
 async def display_metadata(expander: DocumentExpander):
@@ -65,7 +69,7 @@ async def display_metadata(expander: DocumentExpander):
 
 async def display_all(expanders: list[DocumentExpander]):
     displays = [display_metadata(expander) for expander in expanders]
-    await asyncio.gather(*displays, return_exceptions= True)
+    await asyncio.gather(*displays, return_exceptions=True)
 
 
 if "processed_data" in st.session_state and st.session_state.processed_data:

--- a/frontend/pages/7_metadata_UI.py
+++ b/frontend/pages/7_metadata_UI.py
@@ -64,18 +64,14 @@ async def display_metadata(expander: DocumentExpander):
 
 
 async def display_all(expanders: list[DocumentExpander]):
-    a = [display_metadata(expander) for expander in expanders]
-    await asyncio.gather(*a, return_exceptions= True)
+    displays = [display_metadata(expander) for expander in expanders]
+    await asyncio.gather(*displays, return_exceptions= True)
 
 
 if "processed_data" in st.session_state and st.session_state.processed_data:
     # Initialize session state for expander states if not exists
     if "expander_states" not in st.session_state:
         st.session_state.expander_states = {}
-
-    doc_ids = st.session_state.processed_data.keys()
-    response_lst = list(st.session_state.processed_data.items())
-    doc_names = [data["uploaded_filename"] for _, data in response_lst]
 
     expanders = document_multiselect_with_expander()
     runner.run(display_all(expanders))


### PR DESCRIPTION
### **User description**
### Summary

<!-- Provide a concise summary of the changes introduced in this PR. Link to relevant issue(s) if applicable. -->

This PR adds functional wordcloud and metadata pages to the fronend. It also adds an alternate way of getting data from the pdf_processor, allowing documents status to display individually.

---

### Changes Made

<!-- List out major changes in this PR. Be brief but specific. -->

- New wordcloud and metadata pages
- New Classes that deal with components for document handling
- Status messages per document

---

### Context / Rationale

<!-- Why are these changes being made? Is it a bug fix, feature, refactor, etc.? Provide context to help reviewers understand your thought process. -->
The current method of displaying status is shared among all documents. This means an error in one document may be hidden if another document updates it's status after the error has occurred.

---

### Requirements
<!-- Include any design docs, spec references, screenshots, or relevant PRs -->
- [ ] #172 

---

### General Checklist

- [x] I have tested these changes locally
- [x] I have updated relevant documentation or added comments where needed
- [x] I have linked relevant issues and tagged reviewers
- [x] I have followed coding conventions and naming standards


___

### **PR Type**
Enhancement


___

### **Description**
- Add wordcloud and metadata pages to frontend

- Create document components for individual status handling

- Implement async data fetching from PDF processor

- Add multiselect interface for document management


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Frontend Pages"] --> B["Document Components"]
  B --> C["Async API Calls"]
  C --> D["PDF Processor"]
  B --> E["Individual Status"]
  E --> F["User Interface"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>documents.py</strong><dd><code>New document management components</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/components/documents.py

<ul><li>Create <code>DocumentMultiSelect</code> class for managing document selection<br> <li> Add <code>DocumentExpander</code> class for individual document display<br> <li> Implement helper functions for document names and IDs<br> <li> Add context manager support for expanders</ul>


</details>


  </td>
  <td><a href="https://github.com/NotYuSheng/OmniPDF/pull/192/files#diff-68723c4b685c0bed7cb0d911bf62bfda4d802077704baeb55daba91efca8a0a5">+70/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Add metadata page to navigation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/main.py

<ul><li>Add metadata_UI page to navigation<br> <li> Import new metadata page with icon</ul>


</details>


  </td>
  <td><a href="https://github.com/NotYuSheng/OmniPDF/pull/192/files#diff-b2ca51a84b7adeb7627daf85a4c732b27747ce91e275196ab182a323e7842a72">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>4_wordcloud_UI.py</strong><dd><code>Refactor wordcloud page with async processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/pages/4_wordcloud_UI.py

<ul><li>Replace static wordcloud generation with async API calls<br> <li> Add individual document processing with status tracking<br> <li> Implement polling mechanism for wordcloud data<br> <li> Use new document components for UI management</ul>


</details>


  </td>
  <td><a href="https://github.com/NotYuSheng/OmniPDF/pull/192/files#diff-93a62f1492b6823a3673fe7ed58a45f275769f194798c82f421e519a8dbe43ea">+95/-47</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>7_metadata_UI.py</strong><dd><code>New metadata display page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/pages/7_metadata_UI.py

<ul><li>Create new metadata page with async data fetching<br> <li> Implement polling for metadata processing status<br> <li> Add error handling for JSON decode failures<br> <li> Display metadata in dataframe format</ul>


</details>


  </td>
  <td><a href="https://github.com/NotYuSheng/OmniPDF/pull/192/files#diff-cf85afcc8477ac737c8a7d4bb9edf36b8011b2e8a4017993b5c61d8edf6b0bb6">+84/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

