### PR TITLE
config: Set file upload limit to 100MB

### DIFF
--- a/frontend/.streamlit/config.toml
+++ b/frontend/.streamlit/config.toml
@@ -47,7 +47,7 @@ showSidebarNavigation = true
 
 
 [server]
-maxUploadSize = 200
+maxUploadSize = 100
 runOnSave = true
 
 # Enable CORS with allowed origins for security

--- a/frontend/.streamlit/config.toml
+++ b/frontend/.streamlit/config.toml
@@ -47,7 +47,7 @@ showSidebarNavigation = true
 
 
 [server]
-maxUploadSize = 100
+maxUploadSize = 100 # Aligned with nginx client_max_body_size (100M)
 runOnSave = true
 
 # Enable CORS with allowed origins for security


### PR DESCRIPTION
### **User description**
Updated Streamlit maxUploadSize from 200MB to 100MB to match the nginx server-side limit (client_max_body_size 100M).

This ensures consistent file size limits across both client and server sides of the application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Other


___

### **Description**
- Reduced Streamlit file upload limit from 200MB to 100MB

- Aligned client-side limit with nginx server configuration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Streamlit Config"] -- "maxUploadSize: 200MB → 100MB" --> B["Nginx Server"]
  B -- "client_max_body_size: 100M" --> C["Consistent Limits"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.toml</strong><dd><code>Reduce file upload size limit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/.streamlit/config.toml

<ul><li>Changed <code>maxUploadSize</code> from 200 to 100 MB<br> <li> Aligns with nginx server-side file size limit</ul>


</details>


  </td>
  <td><a href="https://github.com/NotYuSheng/OmniPDF/pull/210/files#diff-5b399ece92ad8c675c941a8376cdb1101255de5826e4deebff51521af9b56df0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

