### PR TITLE
feat: Ensure metadata service outputs in English

### DIFF
--- a/metadata_service/models/llm_config.py
+++ b/metadata_service/models/llm_config.py
@@ -42,8 +42,12 @@ Your summarization strategy:
 - Create coherent summaries that capture essential information
 - Use bullet points or structured format when appropriate for clarity
 - Ensure summaries are concise yet comprehensive
+
+IMPORTANT: All output must be in English, regardless of the source document's language.
 """,
-            "default": """If the question cannot be answered, return only the stop token.""",
+            "default": """You are a document metadata extraction assistant.
+
+IMPORTANT: All output must be in English, regardless of the source document's language. If the question cannot be answered, return only the stop token.""",
         }
 
         return system_prompts.get(purpose)
@@ -56,17 +60,17 @@ Your summarization strategy:
             "summary": f"""
 **SUMMARIZATION REQUEST:** {question}
 
-**INSTRUCTIONS:** Create a well-structured summary addressing the request. Organize the information logically and maintain the document's key insights and perspective.
+**INSTRUCTIONS:** Create a well-structured summary addressing the request. Organize the information logically and maintain the document's key insights and perspective. Provide the summary in English only.
 
 **CONTEXT:** {context}
 """,
             "title": f"""
 **QUERY REQUEST:** {question}
 
-**INSTRUCTIONS:** Return the title in the following format:
+**INSTRUCTIONS:** Return the title in English in the following format:
+    Title: Title
 
 **CONTEXT:** {context}
-    Title: Title
 """,
             "authors": f"""
 **QUERY REQUEST:** {question}
@@ -79,7 +83,7 @@ Your summarization strategy:
             "keywords": f"""
 **QUERY REQUEST:** {question}
 
-**INSTRUCTIONS:** Return the list of keywords in the following format:
+**INSTRUCTIONS:** Return the list of keywords in English in the following format:
     Keywords: keyword1, keyword2, keyword3, etc
 
 **CONTEXT:** {context}
@@ -87,8 +91,7 @@ Your summarization strategy:
             "short_description": f"""
 **QUERY REQUEST:** {question}
 
-**INSTRUCTIONS:** Preserve the original meaning of the document while summarizing it into a concise description.
-    Return only the short description.
+**INSTRUCTIONS:** Preserve the original meaning of the document while summarizing it into a concise description in English. Return only the short description.
 
 **CONTEXT:** {context}
 """,


### PR DESCRIPTION
### **User description**
Updated LLM prompt templates to explicitly require English output for all metadata generation, including summaries, titles, keywords, and executive summaries, regardless of source document language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Added explicit English output requirement to all metadata generation prompts

- Updated system and user prompts for consistent language output

- Enhanced prompt instructions for title, keywords, and descriptions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Source Document"] --> B["LLM Prompts"]
  B --> C["Metadata Generation"]
  C --> D["English Output Only"]
  B -.-> E["Language Enforcement Rules"]
  E --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>llm_config.py</strong><dd><code>Enhanced prompts with English output enforcement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

metadata_service/models/llm_config.py

<ul><li>Added "IMPORTANT: All output must be in English" directive to system <br>prompts<br> <li> Updated user prompts for title, keywords, and short_description with <br>English requirement<br> <li> Enhanced default system prompt with metadata extraction context<br> <li> Reorganized title prompt format for better clarity</ul>


</details>


  </td>
  <td><a href="https://github.com/NotYuSheng/OmniPDF/pull/211/files#diff-7df2372136207f56977b5684c6e5a89c64a1441ce67df78875c07f87ed4bf4c7">+10/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

