### PR TITLE
feat: Add version display and WebSocket configuration

### DIFF
--- a/frontend/example.env
+++ b/frontend/example.env
@@ -13,5 +13,12 @@ STREAMLIT_SERVER_ENABLE_CORS=true
 STREAMLIT_SERVER_ENABLE_XSRF_PROTECTION=true
 STREAMLIT_SERVER_CORS_ALLOWED_ORIGINS="http://localhost:8080,http://localhost:8501,http://127.0.0.1:8080,http://127.0.0.1:8501"
 
+# WebSocket Configuration (required when accessing via Tailscale or external IP)
+# Set these to match your access URL (without http://)
+# For Tailscale: STREAMLIT_BROWSER_SERVER_ADDRESS=100.64.0.1
+# For localhost: Comment out or leave empty
+# STREAMLIT_BROWSER_SERVER_ADDRESS=
+# STREAMLIT_BROWSER_SERVER_PORT=8080
+
 # Timezone configuration
 TZ=Asia/Singapore

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -3,6 +3,7 @@ import logging
 import os
 
 from httpx import Cookies
+from version import __version__
 
 # Logger
 logging.basicConfig(level=logging.INFO)
@@ -36,14 +37,14 @@ if __name__ == "__main__":
             text-align: center;
             margin-bottom: 2rem;
         }
-        
+
         .metric-card {
             background-color: #f0f2f6;
             padding: 1rem;
             border-radius: 10px;
             margin: 0.5rem 0;
         }
-        
+
         .image-container {
             border: 2px solid #e6e6e6;
             border-radius: 10px;
@@ -53,6 +54,11 @@ if __name__ == "__main__":
 
         .stTabs [data-baseweb="tab-list"] {
             gap: 2rem;
+        }
+
+        /* Disable sidebar collapse button */
+        [data-testid="collapsedControl"] {
+            display: none;
         }
     </style>
     """,
@@ -114,4 +120,12 @@ if __name__ == "__main__":
             settings_UI,
         ]
     )
+
+    # Add version number to sidebar footer
+    st.sidebar.markdown("---")
+    st.sidebar.markdown(
+        f"<div style='text-align: center; color: #666; font-size: 0.8em;'>v{__version__}</div>",
+        unsafe_allow_html=True
+    )
+
     pg.run()

--- a/frontend/version.py
+++ b/frontend/version.py
@@ -1,0 +1,27 @@
+"""Version information for OmniPDF frontend."""
+import subprocess
+import logging
+
+logger = logging.getLogger(__name__)
+
+def get_version() -> str:
+    """
+    Get the current version from git tags.
+    Falls back to 'dev' if git is not available or no tags exist.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "describe", "--tags", "--always"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except Exception as e:
+        logger.debug(f"Could not get git version: {e}")
+
+    return "dev"
+
+__version__ = get_version()


### PR DESCRIPTION
### **User description**
- Add version.py to dynamically get version from git tags
- Display version number in sidebar footer on all pages
- Add WebSocket configuration to example.env for Tailscale/external access

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Add dynamic version display from git tags

- Show version number in sidebar footer

- Add WebSocket configuration for external access

- Disable sidebar collapse button styling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Git Tags"] --> B["version.py"]
  B --> C["Frontend Sidebar"]
  D["example.env"] --> E["WebSocket Config"]
  C --> F["Version Display"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Add version display and UI improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/main.py

<ul><li>Import version module for dynamic version display<br> <li> Add version number to sidebar footer with styling<br> <li> Add CSS to disable sidebar collapse button<br> <li> Minor whitespace formatting improvements</ul>


</details>


  </td>
  <td><a href="https://github.com/NotYuSheng/OmniPDF/pull/212/files#diff-b2ca51a84b7adeb7627daf85a4c732b27747ce91e275196ab182a323e7842a72">+16/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>version.py</strong><dd><code>Dynamic version retrieval from git tags</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/version.py

<ul><li>Create new module to get version from git tags<br> <li> Implement fallback to 'dev' when git unavailable<br> <li> Use subprocess with timeout for git describe command<br> <li> Export version as <code>__version__</code> variable</ul>


</details>


  </td>
  <td><a href="https://github.com/NotYuSheng/OmniPDF/pull/212/files#diff-588cafe5725708ce3af2488c0772489842dcec51ba20dd3dff2a1c30d2974175">+27/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>example.env</strong><dd><code>WebSocket configuration for external access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/example.env

<ul><li>Add WebSocket configuration section with comments<br> <li> Include settings for Tailscale and external IP access<br> <li> Provide examples for browser server address and port</ul>


</details>


  </td>
  <td><a href="https://github.com/NotYuSheng/OmniPDF/pull/212/files#diff-ede05b732da516bfbc2f22ecb2b15b375d850e86d825812115f266f8b4f8eba4">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

