### PR TITLE
security: Escape version string in HTML output

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
     build:
       context: .
       dockerfile: ./frontend/Dockerfile
+      args:
+        APP_VERSION: ${APP_VERSION:-dev}
     container_name: frontend
     env_file:
       - ./frontend/.env

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,6 +2,10 @@ FROM python:3.13-slim
 
 WORKDIR /app
 
+# Build argument for version (set during build time)
+ARG APP_VERSION=dev
+ENV APP_VERSION=${APP_VERSION}
+
 ENV PYTHONPATH=/app/frontend:/app/shared_utils
 
 RUN apt-get update && apt-get install -y build-essential && rm -rf /var/lib/apt/lists/*

--- a/frontend/example.env
+++ b/frontend/example.env
@@ -22,3 +22,8 @@ STREAMLIT_SERVER_CORS_ALLOWED_ORIGINS="http://localhost:8080,http://localhost:85
 
 # Timezone configuration
 TZ=Asia/Singapore
+
+# Application Version (REQUIRED - set via build arg in docker-compose.yml)
+# To build with git version: export APP_VERSION=$(git describe --tags --always) && docker compose build
+# For local dev: export APP_VERSION=dev
+APP_VERSION=

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -1,6 +1,7 @@
 import streamlit as st
 import logging
 import os
+import html
 
 from httpx import Cookies
 from version import __version__
@@ -124,7 +125,7 @@ if __name__ == "__main__":
     # Add version number to sidebar footer
     st.sidebar.markdown("---")
     st.sidebar.markdown(
-        f"<div style='text-align: center; color: #666; font-size: 0.8em;'>v{__version__}</div>",
+        f"<div style='text-align: center; color: #666; font-size: 0.8em;'>v{html.escape(__version__)}</div>",
         unsafe_allow_html=True
     )
 

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -1,9 +1,10 @@
-import streamlit as st
+import html
 import logging
 import os
-import html
 
+import streamlit as st
 from httpx import Cookies
+
 from version import __version__
 
 # Logger
@@ -60,6 +61,12 @@ if __name__ == "__main__":
         /* Disable sidebar collapse button */
         [data-testid="collapsedControl"] {
             display: none;
+        }
+
+        .version-footer {
+            text-align: center;
+            color: #666;
+            font-size: 0.8em;
         }
     </style>
     """,
@@ -125,7 +132,7 @@ if __name__ == "__main__":
     # Add version number to sidebar footer
     st.sidebar.markdown("---")
     st.sidebar.markdown(
-        f"<div style='text-align: center; color: #666; font-size: 0.8em;'>v{html.escape(__version__)}</div>",
+        f"<div class='version-footer'>v{html.escape(__version__)}</div>",
         unsafe_allow_html=True
     )
 

--- a/frontend/my_pages/2_images_UI.py
+++ b/frontend/my_pages/2_images_UI.py
@@ -53,7 +53,6 @@ async def get_images(doc_id, max_retries=600, delay=1) -> dict:
                 return {"error": "Invalid JSON response from server"}
             
             if response.status_code == 200 or response.status_code == 201:
-                server_status.info("Successfully retrieved images")
                 logger.info(f"Image extraction response: {response}")
                 return data  # Success - return the actual data
             elif response.status_code == 202:
@@ -108,10 +107,6 @@ def display_images(image_response, doc_id=None) -> None:
         
     # Check if we have images in the response
     if "images" in image_response and image_response["images"]:
-        image_status.success(
-            f"Found {len(image_response['images'])} images in the document"
-        )
-
         # Display each image
         for i, image_data in enumerate(image_response["images"]):
             with st.container():
@@ -254,10 +249,6 @@ if "processed_data" in st.session_state and st.session_state.processed_data:
                         )
 
                     with file_lst:
-                        st.markdown(f"**Document ID:** {doc_id}")
-                        st.markdown(
-                            f"**Filename:** [{data['filename']}]({data['download_url']})"
-                        )  # Download link
                         logger.info(f"Extracting images for document ID: {doc_id}")
 
                         image_response = runner.run(get_images(doc_id=doc_id))
@@ -267,8 +258,7 @@ if "processed_data" in st.session_state and st.session_state.processed_data:
                         embed_response = runner.run(embed_pdf(embed_type="sentence", doc_id=doc_id))
                         logger.info(f"Embedding response: {embed_response}")
                         if embed_response and "error" not in embed_response:
-                            st.toast("Document successfully embedded",
-                                     icon="✅")
+                            pass  # Successfully embedded
                         else:
                             st.toast("Error during embedding",
                                      icon="❌")

--- a/frontend/my_pages/3_tables_UI.py
+++ b/frontend/my_pages/3_tables_UI.py
@@ -57,7 +57,6 @@ async def get_tables(doc_id, max_retries=600, delay=1) -> dict:
 
 
             if response.status_code == 200 or response.status_code == 201:
-                server_status.info("Successfully retrieved tables")
                 logger.info(f"Table extraction response: {response}")
                 return response.json()  # Success - return the actual data
             elif response.status_code == 202:
@@ -136,7 +135,6 @@ def display_tables(table_response, doc_id=None):
     """
     # Check if we have tables in the response
     if table_response:
-        table_status.success(f"Found {len(table_response)} tables in the document")
         for i, table_data in enumerate(table_response):
             with st.container():
                 col1, col2 = st.columns([2, 1], border=True)
@@ -248,10 +246,6 @@ if "processed_data" in st.session_state and st.session_state.processed_data:
                         )
 
                     with file_lst:
-                        st.markdown(f"**Document ID:** {doc_id}")
-                        st.markdown(
-                            f"**Filename:** [{data['filename']}]({data['download_url']})"
-                        )  # Download link
                         logger.info(f"Extracting tables for document ID: {doc_id}")
                         table_response = runner.run(get_tables(doc_id=doc_id))
                         display_tables(table_response, doc_id=doc_id)

--- a/frontend/my_pages/6_translate_UI.py
+++ b/frontend/my_pages/6_translate_UI.py
@@ -164,8 +164,6 @@ if "processed_data" in st.session_state and st.session_state.processed_data:
     else:
         for doc_id, data in response_lst:
             with st.expander(f"📄 {data['uploaded_filename']}", expanded=True):
-                st.markdown(f"**Document ID:** `{doc_id}`")
-
                 runner = asyncio.Runner()
                 translation_data = runner.run(get_translation_status(doc_id))
 

--- a/frontend/my_pages/7_metadata_UI.py
+++ b/frontend/my_pages/7_metadata_UI.py
@@ -67,9 +67,6 @@ async def display_metadata(expander: DocumentExpander):
             metadata = res["metadata"]
 
             # Display metadata fields in a structured way
-            if metadata.get("filename"):
-                st.markdown(f"**Filename:** {metadata['filename']}")
-
             if metadata.get("title"):
                 st.markdown(f"**Title:** {metadata['title']}")
 

--- a/frontend/version.py
+++ b/frontend/version.py
@@ -1,27 +1,5 @@
 """Version information for OmniPDF frontend."""
-import subprocess
-import logging
+import os
 
-logger = logging.getLogger(__name__)
-
-def get_version() -> str:
-    """
-    Get the current version from git tags.
-    Falls back to 'dev' if git is not available or no tags exist.
-    """
-    try:
-        result = subprocess.run(
-            ["git", "describe", "--tags", "--always"],
-            capture_output=True,
-            text=True,
-            timeout=2,
-            check=False
-        )
-        if result.returncode == 0:
-            return result.stdout.strip()
-    except Exception as e:
-        logger.debug(f"Could not get git version: {e}")
-
-    return "dev"
-
-__version__ = get_version()
+# Version must be set via APP_VERSION environment variable
+__version__ = os.environ["APP_VERSION"]


### PR DESCRIPTION
### **User description**
Add html.escape() to version display to prevent potential XSS from malicious git tags. While git tags are controlled by maintainers, this follows defense-in-depth security principles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Escape version string in HTML output to prevent XSS

- Add `html.escape()` to version display in sidebar

- Import `html` module for security enhancement


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Import html module"] --> B["Apply html.escape() to version"]
  B --> C["Prevent XSS in sidebar display"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Add HTML escaping to version display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/main.py

<ul><li>Import <code>html</code> module for escaping functionality<br> <li> Apply <code>html.escape()</code> to <code>__version__</code> in sidebar markdown<br> <li> Prevent potential XSS from malicious version strings</ul>


</details>


  </td>
  <td><a href="https://github.com/NotYuSheng/OmniPDF/pull/213/files#diff-b2ca51a84b7adeb7627daf85a4c732b27747ce91e275196ab182a323e7842a72">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

