### PR TITLE
feat: Add per-file translation settings in upload page

### DIFF
--- a/frontend/my_pages/1_upload_UI.py
+++ b/frontend/my_pages/1_upload_UI.py
@@ -332,6 +332,10 @@ uploaded_files = st.file_uploader(
 )
 
 if uploaded_files:
+    # Initialize translation settings in session state if not exists
+    if "translation_settings" not in st.session_state:
+        st.session_state.translation_settings = {}
+
     # Create a list of uploaded files for selection
     file_options = [file.name for file in uploaded_files]
 
@@ -341,37 +345,48 @@ if uploaded_files:
         default=file_options,  # By default, select all uploaded files
     )
 
-    # Translation configuration
+    # Translation configuration per file
     st.markdown("---")
     st.subheader("🌐 Translation Settings")
+    st.markdown("Configure translation settings for each file individually:")
 
-    col1, col2 = st.columns(2)
-    with col1:
-        source_lang = st.selectbox(
-            "Source Language",
-            options=list(LANGUAGES.keys()),
-            format_func=lambda x: LANGUAGES[x],
-            key="upload_source_lang",
-            index=0,  # Default to "Auto-detect"
-            help="Select source language for automatic detection or specify a language"
-        )
+    # Create translation settings for each selected file
+    for file_name in selection:
+        with st.expander(f"📄 {file_name}", expanded=True):
+            col1, col2 = st.columns(2)
 
-    with col2:
-        target_lang = st.selectbox(
-            "Target Language",
-            options=list(LANGUAGES.keys()),
-            format_func=lambda x: LANGUAGES[x],
-            key="upload_target_lang",
-            index=1,  # Default to "English"
-            help="Select target language for translation"
-        )
+            # Initialize default values if not already set
+            if file_name not in st.session_state.translation_settings:
+                st.session_state.translation_settings[file_name] = {
+                    "source_lang": "auto",
+                    "target_lang": "en"
+                }
 
-    st.info(f"🌐 Translation: {LANGUAGES[source_lang]} → {LANGUAGES[target_lang]}")
+            with col1:
+                source_lang = st.selectbox(
+                    "Source Language",
+                    options=list(LANGUAGES.keys()),
+                    format_func=lambda x: LANGUAGES[x],
+                    key=f"source_lang_{file_name}",
+                    index=list(LANGUAGES.keys()).index(st.session_state.translation_settings[file_name]["source_lang"]),
+                    help="Select source language for automatic detection or specify a language"
+                )
+                st.session_state.translation_settings[file_name]["source_lang"] = source_lang
+
+            with col2:
+                target_lang = st.selectbox(
+                    "Target Language",
+                    options=list(LANGUAGES.keys()),
+                    format_func=lambda x: LANGUAGES[x],
+                    key=f"target_lang_{file_name}",
+                    index=list(LANGUAGES.keys()).index(st.session_state.translation_settings[file_name]["target_lang"]),
+                    help="Select target language for translation"
+                )
+                st.session_state.translation_settings[file_name]["target_lang"] = target_lang
+
+            st.info(f"🌐 Translation: {LANGUAGES[source_lang]} → {LANGUAGES[target_lang]}")
 
     st.markdown("---")
-
-    # Translation is always enabled
-    translation_enabled = True
 
     # Check if files are selected and process button is clicked
     if st.button("Process PDF", type="primary"):
@@ -392,11 +407,16 @@ if uploaded_files:
                     file for file in uploaded_files if file.name == file_name
                 )
 
+                # Get translation settings for this specific file
+                file_translation = st.session_state.translation_settings.get(file_name, {})
+                file_source_lang = file_translation.get("source_lang", "auto")
+                file_target_lang = file_translation.get("target_lang", "en")
+
                 # Create an expander for each file
                 file_expander = st.expander(f"📄 {file_name}", expanded=True)
 
-                # Always pass translation settings
-                await process_pdf(file_to_process, file_expander, source_lang, target_lang)
+                # Pass file-specific translation settings
+                await process_pdf(file_to_process, file_expander, file_source_lang, file_target_lang)
 
         asyncio.run(_process_files())
 


### PR DESCRIPTION
### **User description**
Allow users to configure translation source and target languages individually for each uploaded file instead of using global settings.

Changes:
- Create individual translation setting expanders for each file
- Store per-file translation settings in session state
- Pass file-specific translation settings during processing
- Default to auto-detect → English for each file

Benefits:
- Users can translate different files to different languages in one batch
- More flexible workflow for multi-language document processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Replace global translation settings with per-file configuration

- Add individual translation expanders for each uploaded file

- Store file-specific translation settings in session state

- Pass file-specific translation parameters during processing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Upload Files"] --> B["Per-File Settings"]
  B --> C["Session State Storage"]
  C --> D["File Processing"]
  D --> E["Individual Translation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>1_upload_UI.py</strong><dd><code>Per-file translation configuration implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/my_pages/1_upload_UI.py

<ul><li>Replace global translation UI with per-file expanders<br> <li> Initialize and manage translation settings in session state<br> <li> Pass file-specific translation parameters to processing function<br> <li> Default each file to auto-detect source and English target</ul>


</details>


  </td>
  <td><a href="https://github.com/NotYuSheng/OmniPDF/pull/218/files#diff-94fff73a70a259c6227d3a57b6ffea0031ca902592687b1c26e2c947b80aef91">+48/-28</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

