### PR TITLE
Feat/remove expand documents field

### DIFF
--- a/frontend/components/documents.py
+++ b/frontend/components/documents.py
@@ -20,24 +20,16 @@ def document_multiselect_with_expander():
 
 class DocumentMultiSelect():
     def __init__(self):
-        # Update multiselect based on expander states
+        # Initialize expander states for all documents
         self.doc_names = get_document_names()
-        self.multiselect = st.multiselect(
-            label="Expand documents:",
-            options=self.doc_names,
-            default=[
-                doc for doc in self.doc_names if st.session_state.expander_states.get(doc, True)
-            ],
-            help="Choose which documents should be expanded",
-            key="expander_multiselect",
-        )
-        
-        # Update session state based on multiselect
+
+        # Initialize expander states for new documents
         for doc_name in self.doc_names:
-            st.session_state.expander_states[doc_name] = doc_name in self.multiselect
+            if doc_name not in st.session_state.expander_states:
+                st.session_state.expander_states[doc_name] = True
 
     def __contains__(self, item):
-        return item in self.multiselect
+        return True  # All documents are always included
 
 
 class DocumentExpander():

--- a/frontend/my_pages/1_upload_UI.py
+++ b/frontend/my_pages/1_upload_UI.py
@@ -332,6 +332,10 @@ uploaded_files = st.file_uploader(
 )
 
 if uploaded_files:
+    # Initialize translation settings in session state if not exists
+    if "translation_settings" not in st.session_state:
+        st.session_state.translation_settings = {}
+
     # Create a list of uploaded files for selection
     file_options = [file.name for file in uploaded_files]
 
@@ -341,37 +345,48 @@ if uploaded_files:
         default=file_options,  # By default, select all uploaded files
     )
 
-    # Translation configuration
+    # Translation configuration per file
     st.markdown("---")
     st.subheader("🌐 Translation Settings")
+    st.markdown("Configure translation settings for each file individually:")
 
-    col1, col2 = st.columns(2)
-    with col1:
-        source_lang = st.selectbox(
-            "Source Language",
-            options=list(LANGUAGES.keys()),
-            format_func=lambda x: LANGUAGES[x],
-            key="upload_source_lang",
-            index=0,  # Default to "Auto-detect"
-            help="Select source language for automatic detection or specify a language"
-        )
+    # Create translation settings for each selected file
+    for file_name in selection:
+        with st.expander(f"📄 {file_name}", expanded=True):
+            col1, col2 = st.columns(2)
 
-    with col2:
-        target_lang = st.selectbox(
-            "Target Language",
-            options=list(LANGUAGES.keys()),
-            format_func=lambda x: LANGUAGES[x],
-            key="upload_target_lang",
-            index=1,  # Default to "English"
-            help="Select target language for translation"
-        )
+            # Initialize default values if not already set
+            if file_name not in st.session_state.translation_settings:
+                st.session_state.translation_settings[file_name] = {
+                    "source_lang": "auto",
+                    "target_lang": "en"
+                }
 
-    st.info(f"🌐 Translation: {LANGUAGES[source_lang]} → {LANGUAGES[target_lang]}")
+            with col1:
+                source_lang = st.selectbox(
+                    "Source Language",
+                    options=list(LANGUAGES.keys()),
+                    format_func=lambda x: LANGUAGES[x],
+                    key=f"source_lang_{file_name}",
+                    index=list(LANGUAGES.keys()).index(st.session_state.translation_settings[file_name]["source_lang"]),
+                    help="Select source language for automatic detection or specify a language"
+                )
+                st.session_state.translation_settings[file_name]["source_lang"] = source_lang
+
+            with col2:
+                target_lang = st.selectbox(
+                    "Target Language",
+                    options=list(LANGUAGES.keys()),
+                    format_func=lambda x: LANGUAGES[x],
+                    key=f"target_lang_{file_name}",
+                    index=list(LANGUAGES.keys()).index(st.session_state.translation_settings[file_name]["target_lang"]),
+                    help="Select target language for translation"
+                )
+                st.session_state.translation_settings[file_name]["target_lang"] = target_lang
+
+            st.info(f"🌐 Translation: {LANGUAGES[source_lang]} → {LANGUAGES[target_lang]}")
 
     st.markdown("---")
-
-    # Translation is always enabled
-    translation_enabled = True
 
     # Check if files are selected and process button is clicked
     if st.button("Process PDF", type="primary"):
@@ -392,11 +407,16 @@ if uploaded_files:
                     file for file in uploaded_files if file.name == file_name
                 )
 
+                # Get translation settings for this specific file
+                file_translation = st.session_state.translation_settings.get(file_name, {})
+                file_source_lang = file_translation.get("source_lang", "auto")
+                file_target_lang = file_translation.get("target_lang", "en")
+
                 # Create an expander for each file
                 file_expander = st.expander(f"📄 {file_name}", expanded=True)
 
-                # Always pass translation settings
-                await process_pdf(file_to_process, file_expander, source_lang, target_lang)
+                # Pass file-specific translation settings
+                await process_pdf(file_to_process, file_expander, file_source_lang, file_target_lang)
 
         asyncio.run(_process_files())
 

--- a/frontend/my_pages/2_images_UI.py
+++ b/frontend/my_pages/2_images_UI.py
@@ -207,20 +207,6 @@ if "processed_data" in st.session_state and st.session_state.processed_data:
         if doc_name not in st.session_state.expander_states:
             st.session_state.expander_states[doc_name] = True
 
-    # Update multiselect based on expander states
-    expanded_docs = st.multiselect(
-        label="Expand documents:",
-        options=doc_names,
-        default=[
-            doc for doc in doc_names if st.session_state.expander_states.get(doc, True)
-        ],
-        help="Choose which documents should be expanded",
-        key="expander_multiselect",
-    )
-
-    # Update session state based on multiselect
-    for doc_name in doc_names:
-        st.session_state.expander_states[doc_name] = doc_name in expanded_docs
 
     try:
         # Show loading message

--- a/frontend/my_pages/2_images_UI.py
+++ b/frontend/my_pages/2_images_UI.py
@@ -222,17 +222,11 @@ if "processed_data" in st.session_state and st.session_state.processed_data:
                         ),
                     )
 
-                    # Update expander state and multiselect when expander is toggled
+                    # Update expander state when expander is toggled
                     if not file_lst:  # expander is closed
-                        st.session_state.expander_states[data["uploaded_filename"]] = (
-                            False
-                        )
-                        if data["uploaded_filename"] in expanded_docs:
-                            expanded_docs.remove(data["uploaded_filename"])
+                        st.session_state.expander_states[data["uploaded_filename"]] = False
                     else:  # expander is open
-                        st.session_state.expander_states[data["uploaded_filename"]] = (
-                            True
-                        )
+                        st.session_state.expander_states[data["uploaded_filename"]] = True
 
                     with file_lst:
                         logger.info(f"Extracting images for document ID: {doc_id}")

--- a/frontend/my_pages/3_tables_UI.py
+++ b/frontend/my_pages/3_tables_UI.py
@@ -219,17 +219,11 @@ if "processed_data" in st.session_state and st.session_state.processed_data:
                         ),
                     )
 
-                    # Update expander state and multiselect when expander is toggled
+                    # Update expander state when expander is toggled
                     if not file_lst:  # expander is closed
-                        st.session_state.expander_states[data["uploaded_filename"]] = (
-                            False
-                        )
-                        if data["uploaded_filename"] in expanded_docs:
-                            expanded_docs.remove(data["uploaded_filename"])
+                        st.session_state.expander_states[data["uploaded_filename"]] = False
                     else:  # expander is open
-                        st.session_state.expander_states[data["uploaded_filename"]] = (
-                            True
-                        )
+                        st.session_state.expander_states[data["uploaded_filename"]] = True
 
                     with file_lst:
                         logger.info(f"Extracting tables for document ID: {doc_id}")

--- a/frontend/my_pages/3_tables_UI.py
+++ b/frontend/my_pages/3_tables_UI.py
@@ -204,20 +204,6 @@ if "processed_data" in st.session_state and st.session_state.processed_data:
         if doc_name not in st.session_state.expander_states:
             st.session_state.expander_states[doc_name] = True
 
-    # Update multiselect based on expander states
-    expanded_docs = st.multiselect(
-        label="Expand documents:",
-        options=doc_names,
-        default=[
-            doc for doc in doc_names if st.session_state.expander_states.get(doc, True)
-        ],
-        help="Choose which documents should be expanded",
-        key="expander_multiselect",
-    )
-
-    # Update session state based on multiselect
-    for doc_name in doc_names:
-        st.session_state.expander_states[doc_name] = doc_name in expanded_docs
 
     try:
         # Show loading message


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add per-file translation settings in upload page

- Remove 'Expand documents' multiselect from UI tabs

- Simplify document expansion to auto-expand all documents

- Enable individual language configuration for each uploaded file


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Upload Page"] --> B["Per-file Translation Settings"]
  C["Document Tabs"] --> D["Auto-expand All Documents"]
  B --> E["Individual Language Selection"]
  D --> F["Simplified UI"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>documents.py</strong><dd><code>Simplify document expansion to auto-expand all</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/components/documents.py

<ul><li>Remove multiselect widget from <code>DocumentMultiSelect</code> class<br> <li> Auto-expand all documents by default<br> <li> Simplify <code>__contains__</code> method to always return True<br> <li> Initialize expander states for new documents only</ul>


</details>


  </td>
  <td><a href="https://github.com/NotYuSheng/OmniPDF/pull/219/files#diff-68723c4b685c0bed7cb0d911bf62bfda4d802077704baeb55daba91efca8a0a5">+6/-14</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>1_upload_UI.py</strong><dd><code>Add individual translation settings per file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/my_pages/1_upload_UI.py

<ul><li>Add per-file translation settings with individual expanders<br> <li> Store translation settings in session state per file<br> <li> Pass file-specific translation parameters to processing<br> <li> Default each file to auto-detect → English translation</ul>


</details>


  </td>
  <td><a href="https://github.com/NotYuSheng/OmniPDF/pull/219/files#diff-94fff73a70a259c6227d3a57b6ffea0031ca902592687b1c26e2c947b80aef91">+48/-28</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>2_images_UI.py</strong><dd><code>Remove document expansion multiselect widget</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/my_pages/2_images_UI.py

<ul><li>Remove 'Expand documents' multiselect widget<br> <li> Keep expander state initialization for new documents<br> <li> Simplify UI by removing document selection controls</ul>


</details>


  </td>
  <td><a href="https://github.com/NotYuSheng/OmniPDF/pull/219/files#diff-7fbe24ffe96e12cd295d98da01ab44fcd334f8dfd93eb49830f491ccecc7f031">+0/-14</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>3_tables_UI.py</strong><dd><code>Remove document expansion multiselect widget</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/my_pages/3_tables_UI.py

<ul><li>Remove 'Expand documents' multiselect widget<br> <li> Keep expander state initialization for new documents<br> <li> Simplify UI by removing document selection controls</ul>


</details>


  </td>
  <td><a href="https://github.com/NotYuSheng/OmniPDF/pull/219/files#diff-db03ca85ac9126df418f0730663cd80a75d4fbce3d208129f0555a16f55a558f">+0/-14</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

