### PR TITLE
fix: Prune stale translation settings for removed files

### DIFF
--- a/frontend/my_pages/1_upload_UI.py
+++ b/frontend/my_pages/1_upload_UI.py
@@ -336,6 +336,12 @@ if uploaded_files:
     if "translation_settings" not in st.session_state:
         st.session_state.translation_settings = {}
 
+    # Prune stale translation settings for removed files
+    current_file_names = {f.name for f in uploaded_files}
+    stale_files = set(st.session_state.translation_settings.keys()) - current_file_names
+    for file_name in stale_files:
+        del st.session_state.translation_settings[file_name]
+
     # Create a list of uploaded files for selection
     file_options = [file.name for file in uploaded_files]
 


### PR DESCRIPTION
### **User description**
Add cleanup logic to remove translation settings from session state when files are removed from the uploader. This prevents memory accumulation and ensures session state stays synchronized with the current file list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Add cleanup logic for stale translation settings

- Remove settings for files no longer in uploader

- Prevent memory accumulation in session state

- Ensure synchronization between files and settings


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Uploaded Files"] --> B["Get Current File Names"]
  B --> C["Compare with Session State"]
  C --> D["Identify Stale Settings"]
  D --> E["Remove Stale Settings"]
  E --> F["Clean Session State"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>1_upload_UI.py</strong><dd><code>Add cleanup logic for stale translation settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/my_pages/1_upload_UI.py

<ul><li>Add logic to identify stale translation settings<br> <li> Remove settings for files no longer in uploaded_files<br> <li> Prevent memory leaks in session state<br> <li> Maintain synchronization between current files and settings</ul>


</details>


  </td>
  <td><a href="https://github.com/NotYuSheng/OmniPDF/pull/220/files#diff-94fff73a70a259c6227d3a57b6ffea0031ca902592687b1c26e2c947b80aef91">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

